### PR TITLE
Check editor permissions

### DIFF
--- a/lib/editor/actions/active.js
+++ b/lib/editor/actions/active.js
@@ -168,7 +168,7 @@ export function deleteGtfsEntity (feedId, component, entityId, routeId) {
       return dispatch(getGtfsTable(component, feedId))
     }
     var error = false
-    const url = `/api/manager/secure/${component}/${entityId}?feedId=${feedId}`
+    const url = `/api/editor/secure/${component}/${entityId}?feedId=${feedId}`
     return dispatch(secureFetch(url, 'delete'))
       .then(res => {
         if (res.status >= 300) {

--- a/lib/editor/actions/agency.js
+++ b/lib/editor/actions/agency.js
@@ -37,8 +37,8 @@ export function saveAgency (feedId, agency) {
     }
     const method = agency.id !== 'new' ? 'put' : 'post'
     const url = agency.id !== 'new'
-      ? `/api/manager/secure/agency/${agency.id}?feedId=${feedId}`
-      : `/api/manager/secure/agency?feedId=${feedId}`
+      ? `/api/editor/secure/agency/${agency.id}?feedId=${feedId}`
+      : `/api/editor/secure/agency?feedId=${feedId}`
     return dispatch(secureFetch(url, method, data))
       .then(res => res.json())
       .then(a => {
@@ -72,7 +72,7 @@ export function receiveAgencies (feedId, agencies) {
 export function fetchAgencies (feedId) {
   return function (dispatch, getState) {
     dispatch(requestingAgencies(feedId))
-    const url = `/api/manager/secure/agency?feedId=${feedId}`
+    const url = `/api/editor/secure/agency?feedId=${feedId}`
     return dispatch(secureFetch(url))
       .then(res => res.json())
       .then(agencies => {
@@ -96,7 +96,7 @@ export function deleteAgency (feedId, agency) {
     if (agency.id === 'new') {
       return dispatch(fetchAgencies(feedId))
     }
-    const url = `/api/manager/secure/agency/${agency.id}?feedId=${feedId}`
+    const url = `/api/editor/secure/agency/${agency.id}?feedId=${feedId}`
     return dispatch(secureFetch(url, 'delete'))
       .then(res => res.json())
       .then(agency => {

--- a/lib/editor/actions/calendar.js
+++ b/lib/editor/actions/calendar.js
@@ -22,7 +22,7 @@ export function receiveCalendars (feedId, calendars) {
 export function fetchCalendars (feedId) {
   return function (dispatch, getState) {
     dispatch(requestingCalendars(feedId))
-    const url = `/api/manager/secure/calendar?feedId=${feedId}`
+    const url = `/api/editor/secure/calendar?feedId=${feedId}`
     return dispatch(secureFetch(url))
       .then(res => res.json())
       .then(calendars => {
@@ -45,8 +45,8 @@ export function saveCalendar (feedId, calendar) {
     dispatch(savingCalendar(feedId, calendar))
     const method = calendar.id !== 'new' ? 'put' : 'post'
     const url = calendar.id !== 'new'
-      ? `/api/manager/secure/calendar/${calendar.id}?feedId=${feedId}`
-      : `/api/manager/secure/calendar?feedId=${feedId}`
+      ? `/api/editor/secure/calendar/${calendar.id}?feedId=${feedId}`
+      : `/api/editor/secure/calendar?feedId=${feedId}`
     const data = {
       // datatools props
       feedId: calendar.feedId,
@@ -95,7 +95,7 @@ export function deleteCalendar (feedId, calendar) {
     if (calendar.id === 'new') {
       return dispatch(fetchCalendars(feedId))
     }
-    const url = `/api/manager/secure/calendar/${calendar.id}?feedId=${feedId}`
+    const url = `/api/editor/secure/calendar/${calendar.id}?feedId=${feedId}`
     return dispatch(secureFetch(url, 'delete'))
     .then(res => {
       if (res.status >= 300) {
@@ -131,8 +131,8 @@ export function saveScheduleException (feedId, scheduleException) {
     dispatch(savingScheduleException(feedId, scheduleException))
     const method = scheduleException.id !== 'new' ? 'put' : 'post'
     const url = scheduleException.id !== 'new'
-      ? `/api/manager/secure/scheduleexception/${scheduleException.id}?feedId=${feedId}`
-      : `/api/manager/secure/scheduleexception?feedId=${feedId}`
+      ? `/api/editor/secure/scheduleexception/${scheduleException.id}?feedId=${feedId}`
+      : `/api/editor/secure/scheduleexception?feedId=${feedId}`
     const data = {
       // datatools props
       id: scheduleException.id === 'new' ? null : scheduleException.id,
@@ -180,7 +180,7 @@ export function receiveScheduleExceptions (feedId, scheduleExceptions) {
 export function fetchScheduleExceptions (feedId) {
   return function (dispatch, getState) {
     dispatch(requestingScheduleExceptions(feedId))
-    const url = `/api/manager/secure/scheduleexception?feedId=${feedId}`
+    const url = `/api/editor/secure/scheduleexception?feedId=${feedId}`
     return dispatch(secureFetch(url))
       .then(res => res.json())
       .then(scheduleExceptions => {
@@ -204,7 +204,7 @@ export function deleteScheduleException (feedId, scheduleException) {
     if (scheduleException.id === 'new') {
       return dispatch(fetchScheduleExceptions(feedId))
     }
-    const url = `/api/manager/secure/scheduleexception/${scheduleException.id}?feedId=${feedId}`
+    const url = `/api/editor/secure/scheduleexception/${scheduleException.id}?feedId=${feedId}`
     return dispatch(secureFetch(url, 'delete'))
       .then(res => res.json())
       .then(scheduleException => {

--- a/lib/editor/actions/editor.js
+++ b/lib/editor/actions/editor.js
@@ -131,7 +131,7 @@ export function getGtfsTable (tableId, feedId) {
       case 'feedinfo':
         return dispatch(fetchFeedInfo(feedId))
       default:
-        const url = `/api/manager/secure/${tableId}?feedId=${feedId}`
+        const url = `/api/editor/secure/${tableId}?feedId=${feedId}`
         return dispatch(secureFetch(url))
           .then(res => res.json())
           .then(entities => {
@@ -148,7 +148,7 @@ export function uploadBrandingAsset (feedId, entityId, component, file) {
     if (!file) return null
     var data = new window.FormData()
     data.append('file', file)
-    const url = `/api/manager/secure/${component}/${entityId}/uploadbranding?feedId=${feedId}`
+    const url = `/api/editor/secure/${component}/${entityId}/uploadbranding?feedId=${feedId}`
     return fetch(url, {
       method: 'post',
       headers: { 'Authorization': 'Bearer ' + getState().user.token },

--- a/lib/editor/actions/fare.js
+++ b/lib/editor/actions/fare.js
@@ -36,8 +36,8 @@ export function saveFare (feedId, fare) {
     }
     const method = fare.id !== 'new' ? 'put' : 'post'
     const url = fare.id !== 'new'
-      ? `/api/manager/secure/fare/${fare.id}?feedId=${feedId}`
-      : `/api/manager/secure/fare?feedId=${feedId}`
+      ? `/api/editor/secure/fare/${fare.id}?feedId=${feedId}`
+      : `/api/editor/secure/fare?feedId=${feedId}`
     return dispatch(secureFetch(url, method, data))
       .then(res => res.json())
       .then(f => {
@@ -67,7 +67,7 @@ export function deleteFare (feedId, fare) {
     if (fare.id === 'new') {
       return dispatch(fetchFares(feedId))
     }
-    const url = `/api/manager/secure/fare/${fare.id}?feedId=${feedId}`
+    const url = `/api/editor/secure/fare/${fare.id}?feedId=${feedId}`
     return dispatch(secureFetch(url, 'delete'))
       .then(res => res.json())
       .then(fare => {
@@ -94,7 +94,7 @@ export function receiveFares (feedId, fares) {
 export function fetchFares (feedId) {
   return function (dispatch, getState) {
     dispatch(requestingFares(feedId))
-    const url = `/api/manager/secure/fare?feedId=${feedId}`
+    const url = `/api/editor/secure/fare?feedId=${feedId}`
     return dispatch(secureFetch(url))
       .then(res => res.json())
       .then(fares => {

--- a/lib/editor/actions/feedInfo.js
+++ b/lib/editor/actions/feedInfo.js
@@ -25,7 +25,7 @@ export function savingFeedInfo (feedId, feedInfo) {
 export function fetchFeedInfo (feedId) {
   return function (dispatch, getState) {
     dispatch(requestingFeedInfo(feedId))
-    const url = `/api/manager/secure/feedinfo/${feedId}`
+    const url = `/api/editor/secure/feedinfo/${feedId}`
     return dispatch(secureFetch(url))
       .then(res => res.json())
       .then(feedInfo => {
@@ -59,7 +59,7 @@ export function createFeedInfo (feedId) {
       // feedPublisherUrl: feedInfo.feed_publisher_url,
       // feedVersion: feedInfo.feed_version,
     }
-    const url = `/api/manager/secure/feedinfo/${feedId}`
+    const url = `/api/editor/secure/feedinfo/${feedId}`
     return dispatch(secureFetch(url, 'post', data))
       .then((res) => {
         return dispatch(fetchFeedInfo(feedId))
@@ -86,7 +86,7 @@ export function saveFeedInfo (feedId, feedInfo) {
       feedPublisherUrl: feedInfo.feed_publisher_url,
       feedVersion: feedInfo.feed_version
     }
-    const url = `/api/manager/secure/feedinfo/${feedId}`
+    const url = `/api/editor/secure/feedinfo/${feedId}`
     const method = getState().editor.data.tables.feedinfo ? 'put' : 'post'
     return dispatch(secureFetch(url, method, data))
       .then((res) => {
@@ -98,7 +98,7 @@ export function saveFeedInfo (feedId, feedInfo) {
 export function updateFeedInfo (feedInfo, changes) {
   return function (dispatch, getState) {
     dispatch(savingFeedInfo(feedInfo.id))
-    const url = `/api/manager/secure/feedinfo/${feedInfo.id}`
+    const url = `/api/editor/secure/feedinfo/${feedInfo.id}`
     return dispatch(secureFetch(url, 'put', changes))
       .then(res => res.json())
       .then(feedInfo => {

--- a/lib/editor/actions/map/stopStrategies.js
+++ b/lib/editor/actions/map/stopStrategies.js
@@ -86,7 +86,6 @@ export function addStopAtIntersection (latlng, activePattern) {
           return dispatch(addStopAtPoint(latlng, false, patternStops.length, activePattern))
         }))
         .then(stops => {
-          console.log(stops)
           stops.map(s => {
             // add new stop to array
             if (s) {
@@ -166,7 +165,8 @@ export function addStopToPattern (pattern, stop, index) {
         dispatch(updateActiveGtfsEntity(pattern, 'trippattern', {patternStops: patternStops}))
         // saveActiveGtfsEntity('trippattern')
         return dispatch(extendPatternToPoint(pattern, endPoint, {lng: stop.stop_lon, lat: stop.stop_lat}))
-      } else { // if shape coordinates do not exist, add pattern stop and get shape between stops (if multiple stops exist)
+      } else {
+        // if shape coordinates do not exist, add pattern stop and get shape between stops (if multiple stops exist)
         patternStops.push(newStop)
         if (patternStops.length > 1) {
           const previousStop = getState().editor.data.tables.stop.find(s => s.id === patternStops[patternStops.length - 2].stopId)
@@ -177,13 +177,15 @@ export function addStopToPattern (pattern, stop, index) {
             return dispatch(saveActiveGtfsEntity('trippattern'))
           })
         } else {
+          // if only a single stop in the pattern, no need to draw a shape of any kind
           dispatch(updateActiveGtfsEntity(pattern, 'trippattern', {patternStops: patternStops}))
           return dispatch(saveActiveGtfsEntity('trippattern'))
         }
       }
       // TODO: construct shape if not following roads
       // updateActiveGtfsEntity(pattern, 'trippattern', {patternStops: patternStops, shape: {type: 'LineString', coordinates: coordinates}})
-    } else { // if adding stop in middle
+    } else {
+      // if adding stop in middle
       patternStops.splice(index, 0, newStop)
       dispatch(updateActiveGtfsEntity(pattern, 'trippattern', {patternStops: patternStops}))
       return dispatch(saveActiveGtfsEntity('trippattern'))

--- a/lib/editor/actions/route.js
+++ b/lib/editor/actions/route.js
@@ -21,8 +21,8 @@ export function saveRoute (feedId, route) {
   return function (dispatch, getState) {
     const method = route.id !== 'new' ? 'put' : 'post'
     const url = route.id !== 'new'
-      ? `/api/manager/secure/route/${route.id}?feedId=${feedId}`
-      : `/api/manager/secure/route?feedId=${feedId}`
+      ? `/api/editor/secure/route/${route.id}?feedId=${feedId}`
+      : `/api/editor/secure/route?feedId=${feedId}`
     const data = {
       gtfsRouteId: route.route_id,
       agencyId: route.agency_id,
@@ -68,7 +68,7 @@ export function deleteRoute (feedId, routeId) {
     if (routeId === 'new') {
       return dispatch(fetchRoutes(feedId))
     }
-    const url = `/api/manager/secure/route/${routeId}?feedId=${feedId}`
+    const url = `/api/editor/secure/route/${routeId}?feedId=${feedId}`
     return dispatch(secureFetch(url, 'delete'))
       .then(res => res.json())
       .then(route => {
@@ -95,7 +95,7 @@ export function receiveRoutes (feedId, routes) {
 export function fetchRoutes (feedId) {
   return function (dispatch, getState) {
     dispatch(requestingRoutes(feedId))
-    const url = `/api/manager/secure/route?feedId=${feedId}`
+    const url = `/api/editor/secure/route?feedId=${feedId}`
     return dispatch(secureFetch(url))
       .then(res => res.json())
       .then(routes => {

--- a/lib/editor/actions/snapshots.js
+++ b/lib/editor/actions/snapshots.js
@@ -24,7 +24,7 @@ export function receiveSnapshots (feedSource, snapshots) {
 export function fetchSnapshots (feedSource) {
   return function (dispatch, getState) {
     dispatch(requestingSnapshots())
-    const url = `/api/manager/secure/snapshot?feedId=${feedSource.id}`
+    const url = `/api/editor/secure/snapshot?feedId=${feedSource.id}`
     return dispatch(secureFetch(url, 'get'))
       .then((response) => {
         return response.json()
@@ -50,7 +50,7 @@ export function restoredSnapshot (name) {
 export function restoreSnapshot (feedSource, snapshot) {
   return function (dispatch, getState) {
     dispatch(restoringSnapshot())
-    const url = `/api/manager/secure/snapshot/${snapshot.id}/restore`
+    const url = `/api/editor/secure/snapshot/${snapshot.id}/restore`
     return dispatch(secureFetch(url, 'post'))
       .then((response) => {
         return response.json()
@@ -81,7 +81,7 @@ export function downloadedSnapshot (name) {
 export function downloadSnapshotViaToken (feedSource, snapshot) {
   return function (dispatch, getState) {
     dispatch(downloadingSnapshot(feedSource, snapshot))
-    const url = `/api/manager/secure/snapshot/${snapshot.id}/downloadtoken`
+    const url = `/api/editor/secure/snapshot/${snapshot.id}/downloadtoken`
     dispatch(secureFetch(url))
     .then((response) => response.json())
     .then((credentials) => {
@@ -111,7 +111,7 @@ export function createdSnapshot (name) {
 export function createSnapshot (feedSource, name, comment) {
   return function (dispatch, getState) {
     dispatch(creatingSnapshot())
-    const url = `/api/manager/secure/snapshot`
+    const url = `/api/editor/secure/snapshot`
     const payload = {
       feedId: feedSource.id,
       name,
@@ -122,6 +122,7 @@ export function createSnapshot (feedSource, name, comment) {
         return response.json()
       }).then(() => {
         dispatch(createdSnapshot(name))
+        return dispatch(fetchSnapshots(feedSource))
       })
   }
 }
@@ -135,7 +136,7 @@ export function deletingSnapshot () {
 export function deleteSnapshot (feedSource, snapshot) {
   return function (dispatch, getState) {
     dispatch(deletingSnapshot())
-    const url = `/api/manager/secure/snapshot/${snapshot.id}`
+    const url = `/api/editor/secure/snapshot/${snapshot.id}`
     return dispatch(secureFetch(url, 'delete'))
       .then((response) => {
         return response.json()
@@ -156,7 +157,7 @@ export function loadingFeedVersionForEditing (feedVersion) {
 export function loadFeedVersionForEditing (feedVersion) {
   return function (dispatch, getState) {
     dispatch(loadingFeedVersionForEditing())
-    const url = `/api/manager/secure/snapshot/import?feedVersionId=${feedVersion.id}`
+    const url = `/api/editor/secure/snapshot/import?feedVersionId=${feedVersion.id}`
     return dispatch(secureFetch(url, 'post'))
       .then((res) => {
         if (res.status >= 400) {

--- a/lib/editor/actions/stop.js
+++ b/lib/editor/actions/stop.js
@@ -26,8 +26,8 @@ export function saveStop (feedId, stop) {
     dispatch(savingStop(feedId, stop))
     const method = !isNew(stop) ? 'put' : 'post'
     const url = !isNew(stop)
-      ? `/api/manager/secure/stop/${stop.id}?feedId=${feedId}`
-      : `/api/manager/secure/stop?feedId=${feedId}`
+      ? `/api/editor/secure/stop/${stop.id}?feedId=${feedId}`
+      : `/api/editor/secure/stop?feedId=${feedId}`
     const data = stopFromGtfs(stop)
     return dispatch(secureFetch(url, method, data))
       .then(res => res.json())
@@ -61,7 +61,7 @@ export function receiveStops (feedId, stops) {
 export function fetchStops (feedId) {
   return function (dispatch, getState) {
     dispatch(requestingStops(feedId))
-    const url = `/api/manager/secure/stop?feedId=${feedId}`
+    const url = `/api/editor/secure/stop?feedId=${feedId}`
     return dispatch(secureFetch(url))
       .then(res => res.json())
       .then(stops => {
@@ -77,7 +77,7 @@ export function fetchStopsForTripPattern (feedId, tripPatternId) {
       return []
     }
     dispatch(requestingStops(feedId))
-    const url = `/api/manager/secure/stop?feedId=${feedId}&patternId=${tripPatternId}`
+    const url = `/api/editor/secure/stop?feedId=${feedId}&patternId=${tripPatternId}`
     return dispatch(secureFetch(url))
       .then(res => {
         if (res.status >= 400) {
@@ -108,7 +108,7 @@ export function deleteStop (feedId, stop) {
     if (stop.id === 'new') {
       return // dispatch(removeStop(feedId, stop))
     }
-    const url = `/api/manager/secure/stop/${stop.id}?feedId=${feedId}`
+    const url = `/api/editor/secure/stop/${stop.id}?feedId=${feedId}`
     return dispatch(secureFetch(url, 'delete'))
       .then(res => res.json())
       .then(route => {

--- a/lib/editor/actions/trip.js
+++ b/lib/editor/actions/trip.js
@@ -23,7 +23,7 @@ export function receiveTripsForCalendar (feedId, pattern, calendarId, trips) {
 export function fetchTripsForCalendar (feedId, pattern, calendarId) {
   return function (dispatch, getState) {
     dispatch(requestingTripsForCalendar(feedId, pattern, calendarId))
-    const url = `/api/manager/secure/trip?feedId=${feedId}&patternId=${pattern.id}&calendarId=${calendarId}`
+    const url = `/api/editor/secure/trip?feedId=${feedId}&patternId=${pattern.id}&calendarId=${calendarId}`
     return dispatch(secureFetch(url))
       .then(res => res.json())
       .then(trips => {
@@ -59,8 +59,8 @@ export function saveTripsForCalendar (feedId, pattern, calendarId, trips) {
       const tripExists = trip.id !== 'new' && trip.id !== null
       const method = tripExists ? 'put' : 'post'
       const url = tripExists
-        ? `/api/manager/secure/trip/${trip.id}?feedId=${feedId}`
-        : `/api/manager/secure/trip?feedId=${feedId}`
+        ? `/api/editor/secure/trip/${trip.id}?feedId=${feedId}`
+        : `/api/editor/secure/trip?feedId=${feedId}`
       trip.id = tripExists ? trip.id : null
       return dispatch(secureFetch(url, method, trip))
         .then(res => {
@@ -101,7 +101,7 @@ export function saveMultipleTripsForCalendar (feedId, pattern, calendarId, trips
         newTrips.push(t)
       }
     })
-    const createUrl = `/api/manager/secure/trip?feedId=${feedId}`
+    const createUrl = `/api/editor/secure/trip?feedId=${feedId}`
     return dispatch(secureFetch(createUrl, 'post'))
       .then(res => {
         if (res.status >= 300) {
@@ -126,10 +126,10 @@ export function saveMultipleTripsForCalendar (feedId, pattern, calendarId, trips
 
 // export function saveTrip (feedId, trip) {
 //   // return function (dispatch, getState) {
-//     // const url = `/api/manager/secure/trip/?feedId=${feedId}&patternId=${pattern.id}&calendarId=${calendarId}`
+//     // const url = `/api/editor/secure/trip/?feedId=${feedId}&patternId=${pattern.id}&calendarId=${calendarId}`
 //     const url = trip.id !== 'new'
-//       ? `/api/manager/secure/trip/${trip.id}?feedId=${feedId}`
-//       : `/api/manager/secure/trip?feedId=${feedId}`
+//       ? `/api/editor/secure/trip/${trip.id}?feedId=${feedId}`
+//       : `/api/editor/secure/trip?feedId=${feedId}`
 //     return dispatch(secureFetch(url))
 //       .then(res => res.json())
 //       .then(trips => {
@@ -163,7 +163,7 @@ export function deleteTripsForCalendar (feedId, pattern, calendarId, trips) {
     let errorCount = 0
     dispatch(deletingTrips(feedId, pattern, calendarId, trips))
     return Promise.all(trips.map(trip => {
-      const url = `/api/manager/secure/trip/${trip.id}?feedId=${feedId}`
+      const url = `/api/editor/secure/trip/${trip.id}?feedId=${feedId}`
       return dispatch(secureFetch(url, 'delete', trip))
         .then(res => res.json())
         .catch(error => {
@@ -234,7 +234,7 @@ export function removeTrips (indexes) {
 // export function fetchTripsForCalendar (feedId, patternId, calendarId) {
 //   return function (dispatch, getState) {
 //     dispatch(requestingTripsForCalendar(feedId, patternId, calendarId))
-//     const url = `/api/manager/secure/trip?feedId=${feedId}&patternId=${patternId}&calendarId=${calendarId}`
+//     const url = `/api/editor/secure/trip?feedId=${feedId}&patternId=${patternId}&calendarId=${calendarId}`
 //     return dispatch(secureFetch(url))
 //       .then(res => res.json())
 //       .then(trips => {

--- a/lib/editor/actions/tripPattern.js
+++ b/lib/editor/actions/tripPattern.js
@@ -31,7 +31,7 @@ export function receiveTripPattern (feedId, tripPattern) {
 export function fetchTripPatterns (feedId) {
   return function (dispatch, getState) {
     dispatch(requestingTripPatterns(feedId))
-    const url = `/api/manager/secure/trippattern?feedId=${feedId}`
+    const url = `/api/editor/secure/trippattern?feedId=${feedId}`
     return dispatch(secureFetch(url))
       .then(res => {
         if (res.status >= 400) return []
@@ -47,7 +47,7 @@ export function fetchTripPatterns (feedId) {
 export function fetchTripPattern (feedId, tripPatternId) {
   return function (dispatch, getState) {
     dispatch(requestingTripPatternsForRoute(feedId))
-    const url = `/api/manager/secure/trippattern/${tripPatternId}?feedId=${feedId}`
+    const url = `/api/editor/secure/trippattern/${tripPatternId}?feedId=${feedId}`
     return dispatch(secureFetch(url))
       .then(res => {
         if (res.status >= 300) return null
@@ -109,7 +109,7 @@ export function fetchTripPatternsForRoute (feedId, routeId) {
       return []
     }
     dispatch(requestingTripPatternsForRoute(feedId))
-    const url = `/api/manager/secure/trippattern?feedId=${feedId}&routeId=${routeId}`
+    const url = `/api/editor/secure/trippattern?feedId=${feedId}&routeId=${routeId}`
     return dispatch(secureFetch(url))
       .then(res => {
         if (res.status >= 400) {
@@ -143,7 +143,7 @@ export function deleteTripPattern (feedId, tripPattern) {
     if (tripPattern.id === 'new') {
       return dispatch(fetchTripPatternsForRoute(feedId, routeId))
     }
-    const url = `/api/manager/secure/trippattern/${tripPattern.id}?feedId=${feedId}`
+    const url = `/api/editor/secure/trippattern/${tripPattern.id}?feedId=${feedId}`
     return dispatch(secureFetch(url, 'delete'))
       .then(res => res.json())
       .then(tripPattern => {
@@ -166,8 +166,8 @@ export function saveTripPattern (feedId, tripPattern) {
     const routeId = tripPattern.routeId
     const data = {...tripPattern}
     const url = tripPattern.id !== 'new'
-      ? `/api/manager/secure/trippattern/${tripPattern.id}?feedId=${feedId}`
-      : `/api/manager/secure/trippattern?feedId=${feedId}`
+      ? `/api/editor/secure/trippattern/${tripPattern.id}?feedId=${feedId}`
+      : `/api/editor/secure/trippattern?feedId=${feedId}`
     data.id = tripPattern.id === 'new' ? null : tripPattern.id
     return dispatch(secureFetch(url, method, data))
       .then(res => {


### PR DESCRIPTION
Perform a check before all `api/editor/secure`  non-`GET` routes to ensure that the user has permission to edit the feed.  This PR is in conjunction with catalogueglobal/datatools-server#6