### PR TITLE
Fix calendar expiration

### DIFF
--- a/lib/manager/components/FeedSourceTable.js
+++ b/lib/manager/components/FeedSourceTable.js
@@ -180,12 +180,16 @@ class FeedSourceAttributes extends Component {
   render () {
     const { feedSource, messages } = this.props
     const dateFormat = getConfigProperty('application.date_format')
-    const hasErrors = feedSource.latestValidation && feedSource.latestValidation.errorCount > 0
     const hasVersion = feedSource.latestValidation
-    const isExpired = feedSource.latestValidation && feedSource.latestValidation.endDate < +moment()
-    const end = feedSource.latestValidation && moment(feedSource.latestValidation.endDate)
-    const endDate = end && end.format(dateFormat)
-    const timeTo = end && moment().to(end)
+    let hasErrors, latestValidationEndMoment, isExpired, endDate, timeTo
+    if (hasVersion) {
+      hasErrors = hasVersion && feedSource.latestValidation.errorCount > 0
+      latestValidationEndMoment = moment(feedSource.latestValidation.endDate, 'YYYYMMDD')
+      isExpired = hasVersion && latestValidationEndMoment.isBefore(moment())
+      endDate = latestValidationEndMoment.format(dateFormat)
+      timeTo = moment().to(latestValidationEndMoment)
+    }
+
     return (
       <ul className='list-inline' style={{marginBottom: '0px'}}>
         <Attribute

--- a/lib/manager/components/FeedSourceTable.js
+++ b/lib/manager/components/FeedSourceTable.js
@@ -183,9 +183,9 @@ class FeedSourceAttributes extends Component {
     const hasVersion = feedSource.latestValidation
     let hasErrors, latestValidationEndMoment, isExpired, endDate, timeTo
     if (hasVersion) {
-      hasErrors = hasVersion && feedSource.latestValidation.errorCount > 0
+      hasErrors = feedSource.latestValidation.errorCount > 0
       latestValidationEndMoment = moment(feedSource.latestValidation.endDate, 'YYYYMMDD')
-      isExpired = hasVersion && latestValidationEndMoment.isBefore(moment())
+      isExpired = latestValidationEndMoment.isBefore(moment())
       endDate = latestValidationEndMoment.format(dateFormat)
       timeTo = moment().to(latestValidationEndMoment)
     }


### PR DESCRIPTION
The previous way of showing the calendar icon in the Feed Source Table was always showing the feed as expired.  This fixes that.