### PR TITLE
fix(alerts): check for null description before performing find and re…

### DIFF
--- a/lib/alerts/reducers/alerts.js
+++ b/lib/alerts/reducers/alerts.js
@@ -100,7 +100,9 @@ const alerts = (state = defaultState, action) => {
           const alert = {
             id: rtdAlert.Id,
             title: rtdAlert.HeaderText,
-            description: rtdAlert.DescriptionText.replace(/(\r\n)/g, '\n'), // RTD server sends back two-char new lines, which can mess up character limit counts
+            // RTD server sends back two-char new lines, which can mess up character limit counts
+            // Here, we replace any of those occurrences with a single new line char.
+            description: rtdAlert.DescriptionText && rtdAlert.DescriptionText.replace(/(\r\n)/g, '\n'),
             cause: rtdAlert.Cause,
             effect: rtdAlert.Effect,
             editedBy: rtdAlert.EditedBy,


### PR DESCRIPTION
When first mapping alerts received from the MTC database to the UI data format, a find and replace operation is performed on the alert description field to replace extra new line chars.  This was failing for an alert that had a null description.  It's still unclear where this alert came from or why the field was null (generated by some other external process?).