### PR TITLE
Fix alert title and desription null values

### DIFF
--- a/lib/alerts/reducers/alerts.js
+++ b/lib/alerts/reducers/alerts.js
@@ -99,10 +99,13 @@ const alerts = (state = defaultState, action) => {
 
           const alert = {
             id: rtdAlert.Id,
-            title: rtdAlert.HeaderText,
+            // Alert title and description are fields we expect to have values, i.e. they are required fields.
+            // If for some reason they are null, change them to empty strings so as not to upset the application
+            // downstream.
+            title: rtdAlert.HeaderText || '',
             // RTD server sends back two-char new lines, which can mess up character limit counts
             // Here, we replace any of those occurrences with a single new line char.
-            description: rtdAlert.DescriptionText && rtdAlert.DescriptionText.replace(/(\r\n)/g, '\n'),
+            description: rtdAlert.DescriptionText && rtdAlert.DescriptionText.replace(/(\r\n)/g, '\n') || '',
             cause: rtdAlert.Cause,
             effect: rtdAlert.Effect,
             editedBy: rtdAlert.EditedBy,

--- a/lib/alerts/reducers/alerts.js
+++ b/lib/alerts/reducers/alerts.js
@@ -105,7 +105,7 @@ const alerts = (state = defaultState, action) => {
             title: rtdAlert.HeaderText || '',
             // RTD server sends back two-char new lines, which can mess up character limit counts
             // Here, we replace any of those occurrences with a single new line char.
-            description: rtdAlert.DescriptionText && rtdAlert.DescriptionText.replace(/(\r\n)/g, '\n') || '',
+            description: rtdAlert.DescriptionText ? rtdAlert.DescriptionText.replace(/(\r\n)/g, '\n') : '',
             cause: rtdAlert.Cause,
             effect: rtdAlert.Effect,
             editedBy: rtdAlert.EditedBy,

--- a/lib/alerts/selectors/index.js
+++ b/lib/alerts/selectors/index.js
@@ -7,6 +7,8 @@ export const getVisibleAlerts = createSelector(
   [state => state.alerts.all, state => state.alerts.filter],
   (alerts, visibilityFilter) => {
     if (!alerts) return []
+
+    // filter alerts by the search text string
     let visibleAlerts = alerts.filter(alert =>
       alert.title.toLowerCase().indexOf((visibilityFilter.searchText || '').toLowerCase()) !== -1)
 


### PR DESCRIPTION
Alert title and description are fields we expect to have values, i.e. they are required fields.  It looks like an external system had created alerts with null values for these, so things were getting messy downstream.

If for some reason they are null, this fix sets them to empty strings so as not to upset the application.