### PR TITLE
Fix Filtering out TRAMS alerts

### DIFF
--- a/lib/alerts/actions/alerts.js
+++ b/lib/alerts/actions/alerts.js
@@ -107,12 +107,8 @@ export function fetchRtdAlerts () {
         }
         return res.json()
       })
-      .then((alerts) => {
-        return dispatch(receivedRtdAlerts(alerts, getActiveProject(getState())))
-      })
-      .then(() => {
-        return dispatch(fetchStopsAndRoutes(getState().alerts.entities, 'ALERTS'))
-      })
+      .then((alerts) => dispatch(receivedRtdAlerts(alerts, getActiveProject(getState()))))
+      .then(() => dispatch(fetchStopsAndRoutes(getState().alerts.entities, 'ALERTS')))
   }
 }
 

--- a/lib/alerts/reducers/alerts.js
+++ b/lib/alerts/reducers/alerts.js
@@ -76,23 +76,23 @@ const alerts = (state = defaultState, action) => {
 
     case 'RECEIVED_RTD_ALERTS':
       const entityList = []
-      alerts = action.rtdAlerts
-      for (let i = 0; i < alerts.length; i++) {
-        const action = alerts[i]
+      // For MTC, filter out all alerts that were created with the TRAMS tool,
+      // as indicated by EditedBy=TRAMS
+      const alerts = action.rtdAlerts.filter(alert => alert.EditedBy !== 'TRAMS')
+      alerts.forEach(action => {
         if (typeof action !== 'undefined' && action.ServiceAlertEntities && action.ServiceAlertEntities.length > 0) {
           for (var j = 0; j < action.ServiceAlertEntities.length; j++) {
-            const ent = action.ServiceAlertEntities[j]
-            if (ent.StopId !== null) {
-              entityList.push({type: 'stop', entity: ent, gtfs: {}})
+            const entity = action.ServiceAlertEntities[j]
+            if (entity.StopId !== null) {
+              entityList.push({type: 'stop', entity, gtfs: {}})
             }
-            if (ent.RouteId !== null) {
-              entityList.push({type: 'route', entity: ent, gtfs: {}})
+            if (entity.RouteId !== null) {
+              entityList.push({type: 'route', entity, gtfs: {}})
             }
           }
         }
-      }
-      const allAlerts = action.rtdAlerts ? action.rtdAlerts
-        .filter(rtdAlert => rtdAlert.EditedBy !== 'TRAMS')
+      })
+      const allAlerts = alerts ? alerts
         .map(rtdAlert => {
           // let activeIndex = action.projects.findIndex(p => p.id == config.activeProjectId)
           const {activeProject: project} = action
@@ -105,7 +105,9 @@ const alerts = (state = defaultState, action) => {
             title: rtdAlert.HeaderText || '',
             // RTD server sends back two-char new lines, which can mess up character limit counts
             // Here, we replace any of those occurrences with a single new line char.
-            description: rtdAlert.DescriptionText ? rtdAlert.DescriptionText.replace(/(\r\n)/g, '\n') : '',
+            description: rtdAlert.DescriptionText
+              ? rtdAlert.DescriptionText.replace(/(\r\n)/g, '\n')
+              : '',
             cause: rtdAlert.Cause,
             effect: rtdAlert.Effect,
             editedBy: rtdAlert.EditedBy,


### PR DESCRIPTION
Previously TRAMS alerts were causing issues with null title and descriptions, but this PR addresses the fact that the requests for GTFS entities (stops/routes) were partly being determined by unfiltered TRAMS alerts, causing issues due to unexpected inputs.