### PR TITLE
fix(fix download merged project feed to use job monitoring)

### DIFF
--- a/lib/manager/actions/projects.js
+++ b/lib/manager/actions/projects.js
@@ -1,7 +1,9 @@
 import { secureFetch } from '../../common/actions'
-import { updateGtfsFilter } from '../../gtfs/actions/filter'
-import { setErrorMessage, startJobMonitor } from './status'
+import { getConfigProperty } from '../../common/util/config'
 import { fetchProjectFeeds } from './feeds'
+import { updateGtfsFilter } from '../../gtfs/actions/filter'
+import { downloadS3Key } from '../../manager/actions/versions'
+import { setErrorMessage, startJobMonitor } from './status'
 import {getActiveProject} from '../selectors'
 // Bulk Project Actions
 
@@ -267,21 +269,43 @@ export function saveProject (props) {
 
 export function downloadFeedForProject (project) {
   return function (dispatch, getState) {
-    const url = `/api/manager/public/project/${project.id}/download`
-    window.location.assign(url)
-    // return dispatch(secureFetch(url))
-    // .then(response => {
-    //   console.log(response.body)
-    //   return response.body
-    // })
-    // .then(result => {
-    //   // window.location.assign(`/api/manager/downloadfeed/${result.id}`)
-    //   console.log(result)
-    //   var zipName = 'download.zip';
-    //   var a = document.createElement('a');
-    //   a.href = "data:application/zip;base64," + result;
-    //   a.download = zipName;
-    //   a.click();
-    // })
+    const url = `/api/manager/secure/project/${project.id}/download`
+    // window.location.assign(url)
+    return dispatch(secureFetch(url))
+    .then(res => {
+      if (res.status >= 400) {
+        dispatch(setErrorMessage('Error merging project feeds'))
+      } else {
+        dispatch(startJobMonitor())
+      }
+      return res.json()
+    })
+    .then(result => {
+      // window.location.assign(`/api/manager/downloadfeed/${result.id}`)
+      console.log(result)
+      // var zipName = 'download.zip';
+      // var a = document.createElement('a');
+      // a.href = "data:application/zip;base64," + result;
+      // a.download = zipName;
+      // a.click();
+    })
+  }
+}
+
+// Download a GTFS file for a FeedVersion
+export function downloadMergedFeedViaToken (project, isPublic, prefix) {
+  return function (dispatch, getState) {
+    const route = isPublic ? 'public' : 'secure'
+    const url = `/api/manager/${route}/project/${project.id}/downloadtoken`
+    dispatch(secureFetch(url))
+    .then(response => response.json())
+    .then(credentials => {
+      if (getConfigProperty('application.data.use_s3_storage')) {
+        dispatch(downloadS3Key(credentials, `${project.id}.zip`, 'project'))
+      } else {
+        // use token to download feed
+        window.location.assign(`/api/manager/downloadprojectfeed/${credentials.id}`)
+      }
+    })
   }
 }

--- a/lib/manager/actions/status.js
+++ b/lib/manager/actions/status.js
@@ -1,6 +1,7 @@
-import { secureFetch } from '../../common/actions'
-import { fetchFeedSource } from './feeds'
-import { fetchSnapshots } from '../../editor/actions/snapshots'
+import {secureFetch} from '../../common/actions'
+import {fetchFeedSource} from './feeds'
+import {downloadMergedFeedViaToken} from './projects'
+import {fetchSnapshots} from '../../editor/actions/snapshots'
 
 export function setErrorMessage (message, action) {
   return {
@@ -146,6 +147,9 @@ export function handleFinishedJob (job) {
         break
       case 'CREATE_FEEDVERSION_FROM_SNAPSHOT':
         dispatch(fetchFeedSource(job.feedVersion.feedSource.id, true, true))
+        break
+      case 'MERGE_PROJECT_FEEDS':
+        dispatch(downloadMergedFeedViaToken(job.project, false, 'project'))
         break
     }
   }

--- a/lib/manager/actions/versions.js
+++ b/lib/manager/actions/versions.js
@@ -263,7 +263,7 @@ export function fetchFeedVersionIsochrones (feedVersion, fromLat, fromLon, toLat
 }
 
 // Download a GTFS file for a FeedVersion
-export function downloadFeedViaToken (feedVersion, isPublic) {
+export function downloadFeedViaToken (feedVersion, isPublic, prefix = 'gtfs') {
   return function (dispatch, getState) {
     const route = isPublic ? 'public' : 'secure'
     const url = `/api/manager/${route}/feedversion/${feedVersion.id}/downloadtoken`
@@ -271,7 +271,7 @@ export function downloadFeedViaToken (feedVersion, isPublic) {
     .then(response => response.json())
     .then(credentials => {
       if (getConfigProperty('application.data.use_s3_storage')) {
-        dispatch(downloadS3Key(credentials, `${feedVersion.id}`, 'gtfs'))
+        dispatch(downloadS3Key(credentials, `${feedVersion.id}`, prefix))
       } else {
         // use token to download feed
         window.location.assign(`/api/manager/downloadfeed/${credentials.id}`)


### PR DESCRIPTION
Along with catalogueglobal/datatools-server#37, this PR replaces the buggy merge project feeds with a job that, once completed, triggers a download via feed token/s3 credentials.