### PR TITLE
GTFS+ page row fix

### DIFF
--- a/lib/common/util/config.js
+++ b/lib/common/util/config.js
@@ -2,8 +2,14 @@
 
 import objectPath from 'object-path'
 
+import type {GtfsPlusTable} from '../../types'
+
 export function getConfigProperty (propertyString: string): ?any {
   return objectPath.get(window.DT_CONFIG, propertyString)
+}
+
+export function getGtfsPlusSpec (): Array<GtfsPlusTable> {
+  return window.DT_CONFIG.modules.gtfsplus.spec
 }
 
 export function getComponentMessages (componentName: string): any {

--- a/lib/gtfs/components/gtfssearch.js
+++ b/lib/gtfs/components/gtfssearch.js
@@ -15,6 +15,7 @@ export default class GtfsSearch extends Component {
   }
 
   static defaultProps = {
+    autoload: false, // prevent options from auto-loading, esp. when rendering multiple
     entities: ['routes', 'stops'],
     minimumInput: 1
   }
@@ -43,18 +44,19 @@ export default class GtfsSearch extends Component {
   }
 
   _getRoutes = (input) => {
-    const feedIds = this.props.feeds.map(getFeedId)
+    const {feeds, filterByStop} = this.props
+    const feedIds = feeds.map(getFeedId)
 
     if (!feedIds.length) return []
 
     // don't need to use limit here
-    // const limit = this.props.limit ? '&limit=' + this.props.limit : ''
+    // const limit = limit ? '&limit=' + limit : ''
     const nameQuery = input ? '&name=' + input : ''
-    const url = this.props.filterByStop ? `/api/manager/routes?stop=${this.props.filterByStop.stop_id}&feed=${feedIds.toString()}` : `/api/manager/routes?feed=${feedIds.toString()}${nameQuery}`
+    const url = filterByStop
+      ? `/api/manager/routes?stop=${filterByStop.stop_id}&feed=${feedIds.toString()}`
+      : `/api/manager/routes?feed=${feedIds.toString()}${nameQuery}`
     return fetch(url)
-      .then((response) => {
-        return response.json()
-      })
+      .then((response) => response.json())
       .then((routes) => {
         const routeOptions = routes !== null && routes.length > 0
           ? routes.sort((a, b) => {
@@ -65,14 +67,7 @@ export default class GtfsSearch extends Component {
             } else {
               return bRouteName.startsWith(input) ? 1 : aRouteName.localeCompare(bRouteName)
             }
-            // return 0
-          }).map(route => (
-            {
-              route,
-              value: route.route_id,
-              label: `${this.getRouteName(route)} (${route.route_id})`,
-              agency: getFeed(this.props.feeds, route.feed_id)}
-          ))
+          }).map(this._routeToOption)
           : []
         return routeOptions
       })
@@ -89,11 +84,11 @@ export default class GtfsSearch extends Component {
 
     const limit = this.props.limit ? '&limit=' + this.props.limit : ''
     const nameQuery = input ? '&name=' + input : ''
-    const url = this.props.filterByRoute ? `/api/manager/stops?route=${this.props.filterByRoute.route_id}&feed=${feedIds.toString()}${limit}` : `/api/manager/stops?feed=${feedIds.toString()}${nameQuery}${limit}`
+    const url = this.props.filterByRoute
+      ? `/api/manager/stops?route=${this.props.filterByRoute.route_id}&feed=${feedIds.toString()}${limit}`
+      : `/api/manager/stops?feed=${feedIds.toString()}${nameQuery}${limit}`
     return fetch(url)
-      .then((response) => {
-        return response.json()
-      })
+      .then((response) => response.json())
       .then((stops) => {
         const stopOptions = stops !== null && stops.length > 0
           ? stops.sort((a, b) => {
@@ -104,16 +99,7 @@ export default class GtfsSearch extends Component {
             } else {
               return bStopName.startsWith(input) ? 1 : aStopName.localeCompare(bStopName)
             }
-          }).map(stop => {
-            const agency = getFeed(this.props.feeds, stop.feed_id)
-            const id = stop.stop_code ? stop.stop_code : stop.stop_id
-            return {
-              stop,
-              value: stop.stop_id,
-              label: `${stop.stop_name} (${id})`,
-              agency: agency
-            }
-          })
+          }).map(this._stopToOption)
           : []
         return stopOptions
       })
@@ -121,6 +107,26 @@ export default class GtfsSearch extends Component {
         console.log(error)
         return []
       })
+  }
+
+  _routeToOption = route => (
+    {
+      route,
+      value: route.route_id,
+      label: `${this.getRouteName(route)} (${route.route_id})`,
+      agency: getFeed(this.props.feeds, route.feed_id)
+    }
+  )
+
+  _stopToOption = stop => {
+    const agency = getFeed(this.props.feeds, stop.feed_id)
+    const id = stop.stop_code ? stop.stop_code : stop.stop_id
+    return {
+      stop,
+      value: stop.stop_id,
+      label: `${stop.stop_name} (${id})`,
+      agency
+    }
   }
 
   getRouteName = (route) => {
@@ -163,7 +169,8 @@ export default class GtfsSearch extends Component {
   }
 
   render () {
-    const placeholder = this.props.placeholder || 'Begin typing to search for ' + this.props.entities.join(' or ') + '...'
+    const {entities, placeholder: propsPlaceholder} = this.props
+    const placeholder = propsPlaceholder || 'Begin typing to search for ' + entities.join(' or ') + '...'
     return (
       <Select.Async
         {...this.props}

--- a/lib/gtfs/components/gtfssearch.js
+++ b/lib/gtfs/components/gtfssearch.js
@@ -43,6 +43,8 @@ export default class GtfsSearch extends Component {
     )
   }
 
+  // FIXME: use the GraphQL endpoint to fetch routes (GraphQL needs stop
+  // filtering and string query)
   _getRoutes = (input) => {
     const {feeds, filterByStop} = this.props
     const feedIds = feeds.map(getFeedId)
@@ -77,6 +79,8 @@ export default class GtfsSearch extends Component {
       })
   }
 
+  // FIXME: use the GraphQL endpoint to fetch stops (GraphQL needs route
+  // filtering and string query)
   _getStops = (input) => {
     const feedIds = this.props.feeds.map(getFeedId)
     // console.log(feedIds)

--- a/lib/gtfs/components/gtfssearch.js
+++ b/lib/gtfs/components/gtfssearch.js
@@ -69,7 +69,7 @@ export default class GtfsSearch extends Component {
             } else {
               return bRouteName.startsWith(input) ? 1 : aRouteName.localeCompare(bRouteName)
             }
-          }).map(this._routeToOption)
+          }).map(this._entityToOption)
           : []
         return routeOptions
       })
@@ -103,7 +103,7 @@ export default class GtfsSearch extends Component {
             } else {
               return bStopName.startsWith(input) ? 1 : aStopName.localeCompare(bStopName)
             }
-          }).map(this._stopToOption)
+          }).map(this._entityToOption)
           : []
         return stopOptions
       })
@@ -113,23 +113,16 @@ export default class GtfsSearch extends Component {
       })
   }
 
-  _routeToOption = route => (
-    {
-      route,
-      value: route.route_id,
-      label: `${this.getRouteName(route)} (${route.route_id})`,
-      agency: getFeed(this.props.feeds, route.feed_id)
-    }
-  )
-
-  _stopToOption = stop => {
-    const agency = getFeed(this.props.feeds, stop.feed_id)
-    const id = stop.stop_code ? stop.stop_code : stop.stop_id
+  _entityToOption = entity => {
+    const type = entity.stop_id ? 'stop' : 'route'
+    const label = type === 'stop'
+      ? `${entity.stop_name} (${entity.stop_code ? entity.stop_code : entity.stop_id})`
+      : `${this.getRouteName(entity)} (${entity.route_id})`
     return {
-      stop,
-      value: stop.stop_id,
-      label: `${stop.stop_name} (${id})`,
-      agency
+      [type]: entity,
+      label,
+      value: type === 'stop' ? entity.stop_id : entity.route_id,
+      agency: getFeed(this.props.feeds, entity.feed_id)
     }
   }
 

--- a/lib/gtfsplus/actions/gtfsplus.js
+++ b/lib/gtfsplus/actions/gtfsplus.js
@@ -3,7 +3,7 @@ import fetch from 'isomorphic-fetch'
 import {createAction} from 'redux-actions'
 
 import { secureFetch } from '../../common/actions'
-import { getConfigProperty } from '../../common/util/config'
+import { getGtfsPlusSpec } from '../../common/util/config'
 // import {stopsAndRoutes, compose} from '../../gtfs/util/graphql'
 import { fetchFeedVersions } from '../../manager/actions/versions'
 
@@ -172,7 +172,7 @@ export function loadGtfsEntities (tableId, rows, feedSource, feedVersionId) {
     const getDataType = function (tableId, fieldName) {
       const lookupKey = tableId + ':' + fieldName
       if (lookupKey in typeLookup) return typeLookup[lookupKey]
-      const fieldInfo = getConfigProperty('modules.gtfsplus.spec')
+      const fieldInfo = getGtfsPlusSpec()
         .find(t => t.id === tableId).fields.find(f => f.name === fieldName)
       if (!fieldInfo) return null
       typeLookup[lookupKey] = fieldInfo.inputType

--- a/lib/gtfsplus/actions/gtfsplus.js
+++ b/lib/gtfsplus/actions/gtfsplus.js
@@ -5,7 +5,6 @@ import { secureFetch } from '../../common/actions'
 import { getConfigProperty } from '../../common/util/config'
 // import {stopsAndRoutes, compose} from '../../gtfs/util/graphql'
 import { fetchFeedVersions } from '../../manager/actions/versions'
-import { getFeedId } from '../../common/util/modules'
 
 // EDIT ACTIVE GTFS+ ACTIONS
 
@@ -180,7 +179,7 @@ export function receiveGtfsEntities (gtfsEntities) {
   }
 }
 
-export function loadGtfsEntities (tableId, rows, feedSource) {
+export function loadGtfsEntities (tableId, rows, feedSource, feedVersionId) {
   return function (dispatch, getState) {
     // lookup table for mapping tableId:fieldName keys to inputType values
     const typeLookup = {}
@@ -221,23 +220,32 @@ export function loadGtfsEntities (tableId, rows, feedSource) {
     //     return dispatch(receivedStopsAndRoutes(results))
     //   })
 
+    // FIXME: major issue here with feedId vs. feedVersionId.
+    // Basically, feedId will only reference the published feed version.
+    // Here in the GTFS+ editor, we always want routes/stops from the
+    // feedVersionId because there may be new routes/stops here that don't exist
+    // in the published version.
     if (routesToLoad.length === 0 && stopsToLoad.length === 0) return
-    const feedId = getFeedId(feedSource)
+    const feedId = feedVersionId.replace('.zip', '')
+    console.log(`fetching routes ${routesToLoad.join(',')}`)
+    console.log(`fetching stops ${stopsToLoad.join(',')}`)
     var loadRoutes = Promise.all(routesToLoad.map(routeId => {
       const url = `/api/manager/routes/${routeId}?feed=${feedId}`
       return fetch(url)
       .then((response) => response.json())
+      .catch(err => console.log(err))
     }))
 
     var loadStops = Promise.all(stopsToLoad.map(stopId => {
       const url = `/api/manager/stops/${stopId}?feed=${feedId}`
       return fetch(url)
       .then((response) => response.json())
+      .catch(err => console.log(err))
     }))
 
     Promise.all([loadRoutes, loadStops]).then(results => {
-      const loadedRoutes = results[0]
-      const loadedStops = results[1]
+      const loadedRoutes = results[0].filter(res => res) // filter out undefined
+      const loadedStops = results[1].filter(res => res) // filter out undefined
       dispatch(receiveGtfsEntities(loadedRoutes.concat(loadedStops)))
     })
   }

--- a/lib/gtfsplus/actions/gtfsplus.js
+++ b/lib/gtfsplus/actions/gtfsplus.js
@@ -1,5 +1,6 @@
 import JSZip from 'jszip'
 import fetch from 'isomorphic-fetch'
+import {createAction} from 'redux-actions'
 
 import { secureFetch } from '../../common/actions'
 import { getConfigProperty } from '../../common/util/config'
@@ -8,30 +9,15 @@ import { fetchFeedVersions } from '../../manager/actions/versions'
 
 // EDIT ACTIVE GTFS+ ACTIONS
 
-export function addGtfsPlusRow (tableId) {
-  const table = getConfigProperty('modules.gtfsplus.spec').find(t => t.id === tableId)
+export const addGtfsPlusRow = createAction('ADD_GTFSPLUS_ROW')
 
-  const rowData = {}
-  for (const field of table.fields) {
-    rowData[field.name] = null
-  }
+export const setActiveTable = createAction('SET_ACTIVE_GTFSPLUS_TABLE')
 
-  return {
-    type: 'ADD_GTFSPLUS_ROW',
-    tableId,
-    rowData
-  }
-}
+export const setCurrentPage = createAction('SET_CURRENT_GTFSPLUS_PAGE')
 
-export function updateGtfsPlusField (tableId, rowIndex, fieldName, newValue) {
-  return {
-    type: 'UPDATE_GTFSPLUS_FIELD',
-    tableId,
-    rowIndex,
-    fieldName,
-    newValue
-  }
-}
+export const setVisibilityFilter = createAction('SET_GTFSPLUS_VISIBILITY')
+
+export const updateGtfsPlusField = createAction('UPDATE_GTFSPLUS_FIELD')
 
 export function deleteGtfsPlusRow (tableId, rowIndex) {
   return {
@@ -227,8 +213,6 @@ export function loadGtfsEntities (tableId, rows, feedSource, feedVersionId) {
     // in the published version.
     if (routesToLoad.length === 0 && stopsToLoad.length === 0) return
     const feedId = feedVersionId.replace('.zip', '')
-    console.log(`fetching routes ${routesToLoad.join(',')}`)
-    console.log(`fetching stops ${stopsToLoad.join(',')}`)
     var loadRoutes = Promise.all(routesToLoad.map(routeId => {
       const url = `/api/manager/routes/${routeId}?feed=${feedId}`
       return fetch(url)

--- a/lib/gtfsplus/components/GtfsPlusEditor.js
+++ b/lib/gtfsplus/components/GtfsPlusEditor.js
@@ -6,7 +6,7 @@ import { Link } from 'react-router'
 import ManagerPage from '../../common/components/ManagerPage'
 import OptionButton from '../../common/components/OptionButton'
 import GtfsPlusTable from './GtfsPlusTable'
-import { getConfigProperty } from '../../common/util/config'
+import { getGtfsPlusSpec } from '../../common/util/config'
 
 export default class GtfsPlusEditor extends Component {
   static propTypes = {
@@ -35,7 +35,7 @@ export default class GtfsPlusEditor extends Component {
   save = () => {
     const zip = new JSZip()
 
-    for (const table of getConfigProperty('modules.gtfsplus.spec')) {
+    for (const table of getGtfsPlusSpec()) {
       if (!(table.id in this.props.tableData) || this.props.tableData[table.id].length === 0) continue
 
       let fileContent = ''
@@ -73,10 +73,10 @@ export default class GtfsPlusEditor extends Component {
 
   _showHelpClicked = (tableId, fieldName) => {
     const helpContent = fieldName
-      ? getConfigProperty('modules.gtfsplus.spec')
+      ? getGtfsPlusSpec()
           .find(t => t.id === tableId).fields
             .find(f => f.name === fieldName).helpContent
-      : getConfigProperty('modules.gtfsplus.spec')
+      : getGtfsPlusSpec()
           .find(t => t.id === tableId).helpContent
     this.refs.page.showInfoModal({
       title: `Help for ${tableId}.txt` + (fieldName ? `: ${fieldName}` : ''),
@@ -104,7 +104,7 @@ export default class GtfsPlusEditor extends Component {
       whiteSpace: 'nowrap'
     }
 
-    const activeTable = getConfigProperty('modules.gtfsplus.spec').find(t => t.id === activeTableId)
+    const activeTable = getGtfsPlusSpec().find(t => t.id === activeTableId)
 
     return (
       <ManagerPage ref='page'>
@@ -137,7 +137,7 @@ export default class GtfsPlusEditor extends Component {
 
           <Row>
             <Col xs={2}>
-              {getConfigProperty('modules.gtfsplus.spec').map((table, index) => {
+              {getGtfsPlusSpec().map((table, index) => {
                 const tableLength = tableData[table.id] && tableData[table.id].length
                 return (<p key={index}>
                   <OptionButton

--- a/lib/gtfsplus/components/GtfsPlusEditor.js
+++ b/lib/gtfsplus/components/GtfsPlusEditor.js
@@ -96,14 +96,6 @@ export default class GtfsPlusEditor extends Component {
     } = this.props
     if (!feedSource) return null
     const editingIsDisabled = !user.permissions.hasFeedPermission(feedSource.organizationId, feedSource.projectId, feedSource.id, 'edit-gtfs')
-    const buttonStyle = {
-      display: 'block',
-      width: '100%',
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-      whiteSpace: 'nowrap'
-    }
-
     const activeTable = getGtfsPlusSpec().find(t => t.id === activeTableId)
 
     return (
@@ -143,10 +135,8 @@ export default class GtfsPlusEditor extends Component {
                   <OptionButton
                     active={table.id === activeTableId}
                     key={table.id}
-                    style={{
-                      color: tableLength ? 'black' : 'grey',
-                      ...buttonStyle
-                    }}
+                    className={'gtfsplus-table-button'}
+                    style={{color: tableLength ? 'black' : 'grey'}}
                     title={table.id}
                     value={table.id}
                     onClick={this._selectTable}>

--- a/lib/gtfsplus/components/GtfsPlusEditor.js
+++ b/lib/gtfsplus/components/GtfsPlusEditor.js
@@ -95,8 +95,9 @@ export default class GtfsPlusEditor extends Component {
       visibleRows
     } = this.props
     if (!feedSource) return null
+    const GTFS_PLUS_SPEC = getGtfsPlusSpec()
     const editingIsDisabled = !user.permissions.hasFeedPermission(feedSource.organizationId, feedSource.projectId, feedSource.id, 'edit-gtfs')
-    const activeTable = getGtfsPlusSpec().find(t => t.id === activeTableId)
+    const activeTable = GTFS_PLUS_SPEC.find(t => t.id === activeTableId)
 
     return (
       <ManagerPage ref='page'>
@@ -129,7 +130,7 @@ export default class GtfsPlusEditor extends Component {
 
           <Row>
             <Col xs={2}>
-              {getGtfsPlusSpec().map((table, index) => {
+              {GTFS_PLUS_SPEC.map((table, index) => {
                 const tableLength = tableData[table.id] && tableData[table.id].length
                 return (<p key={index}>
                   <OptionButton

--- a/lib/gtfsplus/components/GtfsPlusEditor.js
+++ b/lib/gtfsplus/components/GtfsPlusEditor.js
@@ -1,5 +1,5 @@
 import React, {Component, PropTypes} from 'react'
-import { Grid, Row, Col, Button, Glyphicon, PageHeader } from 'react-bootstrap'
+import {Grid, Row, Col, Button, Glyphicon, PageHeader} from 'react-bootstrap'
 import JSZip from 'jszip'
 import { Link } from 'react-router'
 
@@ -20,13 +20,12 @@ export default class GtfsPlusEditor extends Component {
     newRowClicked: PropTypes.func,
     onComponentMount: PropTypes.func,
     project: PropTypes.object,
+    setActiveTable: PropTypes.func,
+    setCurrentPage: PropTypes.func,
+    setVisibilityFilter: PropTypes.func,
     tableData: PropTypes.object,
     user: PropTypes.object,
     validation: PropTypes.object
-  }
-
-  state = {
-    activeTableId: 'realtime_routes'
   }
 
   componentWillMount () {
@@ -66,11 +65,11 @@ export default class GtfsPlusEditor extends Component {
   _gtfsEntitySelected = (type, entity) => this.props.gtfsEntitySelected(type, entity)
 
   _newRowsDisplayed = (rows) => {
-    const {feedSource, feedVersionId, loadGtfsEntities} = this.props
-    loadGtfsEntities(this.state.activeTableId, rows, feedSource, feedVersionId)
+    const {activeTableId, feedSource, feedVersionId, loadGtfsEntities} = this.props
+    loadGtfsEntities(activeTableId, rows, feedSource, feedVersionId)
   }
 
-  _selectTable = (activeTableId) => this.setState({activeTableId})
+  _selectTable = (activeTableId) => this.props.setActiveTable({activeTableId})
 
   _showHelpClicked = (tableId, fieldName) => {
     const helpContent = fieldName
@@ -87,23 +86,25 @@ export default class GtfsPlusEditor extends Component {
 
   render () {
     const {
+      activeTableId,
       feedSource,
-      deleteRowClicked,
-      fieldEdited,
-      newRowClicked,
       project,
       tableData,
       user,
-      validation
+      validation,
+      visibleRows
     } = this.props
     if (!feedSource) return null
     const editingIsDisabled = !user.permissions.hasFeedPermission(feedSource.organizationId, feedSource.projectId, feedSource.id, 'edit-gtfs')
     const buttonStyle = {
       display: 'block',
-      width: '100%'
+      width: '100%',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap'
     }
 
-    const activeTable = getConfigProperty('modules.gtfsplus.spec').find(t => t.id === this.state.activeTableId)
+    const activeTable = getConfigProperty('modules.gtfsplus.spec').find(t => t.id === activeTableId)
 
     return (
       <ManagerPage ref='page'>
@@ -137,11 +138,16 @@ export default class GtfsPlusEditor extends Component {
           <Row>
             <Col xs={2}>
               {getConfigProperty('modules.gtfsplus.spec').map((table, index) => {
+                const tableLength = tableData[table.id] && tableData[table.id].length
                 return (<p key={index}>
                   <OptionButton
-                    bsStyle={table.id === this.state.activeTableId ? 'info' : 'default'}
+                    active={table.id === activeTableId}
                     key={table.id}
-                    style={buttonStyle}
+                    style={{
+                      color: tableLength ? 'black' : 'grey',
+                      ...buttonStyle
+                    }}
+                    title={table.id}
                     value={table.id}
                     onClick={this._selectTable}>
                     {validation && (table.id in validation)
@@ -155,14 +161,11 @@ export default class GtfsPlusEditor extends Component {
             </Col>
             <Col xs={10}>
               <GtfsPlusTable
+                {...this.props}
                 ref='activeTable'
-                feedSource={feedSource}
                 table={activeTable}
-                tableData={tableData[activeTable.id]}
-                validation={validation[activeTable.id]}
-                newRowClicked={newRowClicked}
-                deleteRowClicked={deleteRowClicked}
-                fieldEdited={fieldEdited}
+                rows={visibleRows}
+                validation={validation[activeTable.id] || []}
                 gtfsEntitySelected={this._gtfsEntitySelected}
                 getGtfsEntity={this._getGtfsEntity}
                 showHelpClicked={this._showHelpClicked}

--- a/lib/gtfsplus/components/GtfsPlusEditor.js
+++ b/lib/gtfsplus/components/GtfsPlusEditor.js
@@ -12,11 +12,12 @@ export default class GtfsPlusEditor extends Component {
   static propTypes = {
     deleteRowClicked: PropTypes.func,
     feedSource: PropTypes.object,
+    feedVersionId: PropTypes.string,
     fieldEdited: PropTypes.func,
     gtfsEntityLookup: PropTypes.object,
     gtfsEntitySelected: PropTypes.func,
+    loadGtfsEntities: PropTypes.func,
     newRowClicked: PropTypes.func,
-    newRowsDisplayed: PropTypes.func,
     onComponentMount: PropTypes.func,
     project: PropTypes.object,
     tableData: PropTypes.object,
@@ -64,7 +65,10 @@ export default class GtfsPlusEditor extends Component {
 
   _gtfsEntitySelected = (type, entity) => this.props.gtfsEntitySelected(type, entity)
 
-  _newRowsDisplayed = (rows) => this.props.newRowsDisplayed(this.state.activeTableId, rows, this.props.feedSource)
+  _newRowsDisplayed = (rows) => {
+    const {feedSource, feedVersionId, loadGtfsEntities} = this.props
+    loadGtfsEntities(this.state.activeTableId, rows, feedSource, feedVersionId)
+  }
 
   _selectTable = (activeTableId) => this.setState({activeTableId})
 

--- a/lib/gtfsplus/components/GtfsPlusField.js
+++ b/lib/gtfsplus/components/GtfsPlusField.js
@@ -17,25 +17,26 @@ export default class GtfsPlusField extends Component {
   }
 
   _onChangeRoute = ({route}) => {
-    const {field, fieldEdited, gtfsEntitySelected, row, table} = this.props
-    fieldEdited(table.id, row, field.name, route.route_id)
+    const {field, fieldEdited, gtfsEntitySelected, row: rowIndex, table} = this.props
+    // tableId, rowIndex, fieldName, newValue
+    fieldEdited({tableId: table.id, rowIndex, fieldName: field.name, newValue: route.route_id})
     gtfsEntitySelected('route', route)
   }
 
   _onChangeStop = ({stop}) => {
-    const {field, fieldEdited, gtfsEntitySelected, row, table} = this.props
-    fieldEdited(table.id, row, field.name, stop.stop_id)
+    const {field, fieldEdited, gtfsEntitySelected, row: rowIndex, table} = this.props
+    fieldEdited({tableId: table.id, rowIndex, fieldName: field.name, newValue: stop.stop_id})
     gtfsEntitySelected('stop', stop)
   }
 
-  _onChangeValue = (value) => {
-    const {field, fieldEdited, row, table} = this.props
-    fieldEdited(table.id, row, field.name, value)
+  _onChangeValue = (newValue) => {
+    const {field, fieldEdited, row: rowIndex, table} = this.props
+    fieldEdited({tableId: table.id, rowIndex, fieldName: field.name, newValue})
   }
 
   _onChange = ({target}) => {
-    const {field, fieldEdited, row, table} = this.props
-    fieldEdited(table.id, row, field.name, target.value)
+    const {field, fieldEdited, row: rowIndex, table} = this.props
+    fieldEdited({tableId: table.id, rowIndex, fieldName: field.name, newValue: target.value})
   }
 
   render () {
@@ -56,7 +57,7 @@ export default class GtfsPlusField extends Component {
         const option = currentValue !== null && field.options.find(o => o.value.toUpperCase() === currentValue.toUpperCase())
         return (
           <FormControl componentClass='select'
-            value={option ? option.value : undefined}
+            value={option ? option.value : ''}
             onChange={this._onChange}>
             {/* Add field for empty string value if that is not an allowable option so that user selection triggers onChange */}
             {field.options.findIndex(option => option.value === '') === -1

--- a/lib/gtfsplus/components/GtfsPlusTable.js
+++ b/lib/gtfsplus/components/GtfsPlusTable.js
@@ -5,99 +5,58 @@ import OptionButton from '../../common/components/OptionButton'
 import GtfsPlusField from './GtfsPlusField'
 import GtfsPlusFieldHeader from './GtfsPlusFieldHeader'
 
-const RECORDS_PER_PAGE = 25
-
 export default class GtfsPlusTable extends Component {
   static propTypes = {
-    table: PropTypes.object,
-    tableData: PropTypes.array,
-    validation: PropTypes.object,
     newRowClicked: PropTypes.func,
+    currentPage: PropTypes.number,
     deleteRowClicked: PropTypes.func,
     fieldEdited: PropTypes.func,
     gtfsEntitySelected: PropTypes.func,
     getGtfsEntity: PropTypes.func,
+    newRowsDisplayed: PropTypes.func,
+    pageCount: PropTypes.number,
+    recordsPerPage: PropTypes.number,
+    rows: PropTypes.array,
+    setVisibilityFilter: PropTypes.func,
     showHelpClicked: PropTypes.func,
-    newRowsDisplayed: PropTypes.func
-  }
-
-  state = {
-    currentPage: 1,
-    pageCount: this.props.tableData ? Math.ceil(this.props.tableData.length / RECORDS_PER_PAGE) : 0,
-    visibility: 'all'
-  }
-
-  componentWillReceiveProps (nextProps) {
-    if (this.props.table !== nextProps.table) {
-      this.setState({ currentPage: 1 })
-    }
-    const nextTableLength = nextProps.tableData && nextProps.tableData.length
-    const tableLength = this.props.tableData && this.props.tableData.length
-    if (tableLength !== nextTableLength && nextProps.tableData) {
-      const pageCount = Math.ceil(nextTableLength / RECORDS_PER_PAGE)
-      // If current page becomes greater than page count (e.g., after deleting rows)
-      // or page count increases (e.g., after adding rows), set current page to
-      // page count to avoid confusion for user (user has added a row, but they
-      // don't see it because the current page has not updated).
-      const currentPage = this.state.currentPage > pageCount || pageCount > this.state.pageCount
-        ? pageCount
-        : this.state.currentPage
-      this.setState({currentPage, pageCount})
-    }
+    table: PropTypes.object,
+    validation: PropTypes.array,
+    visibility: PropTypes.string
   }
 
   componentDidMount () {
-    this.props.newRowsDisplayed(this.getActiveRowData(this.state.currentPage))
+    this.props.newRowsDisplayed(this.props.rows)
   }
 
   componentDidUpdate () {
-    this.props.newRowsDisplayed(this.getActiveRowData(this.state.currentPage))
+    this.props.newRowsDisplayed(this.props.rows)
   }
 
-  getActiveRowData (currentPage) {
-    const {tableData, validation} = this.props
-    if (!tableData) return []
-    const tableValidation = validation || []
-    if (this.state.visibility === 'validation' && tableValidation.length < 5000) {
-      return tableData
-        .filter(record => (tableValidation.find(v => v.rowIndex === record.origRowIndex)))
-        .slice((currentPage - 1) * RECORDS_PER_PAGE,
-          Math.min(currentPage * RECORDS_PER_PAGE, tableData.length))
-    }
-    return tableData
-      .slice((currentPage - 1) * RECORDS_PER_PAGE,
-        Math.min(currentPage * RECORDS_PER_PAGE, tableData.length))
-  }
+  _onChangeVisibleRows = (evt) => this.props.setVisibilityFilter({visibility: evt.target.value})
 
-  _onChangeVisibleRows = (evt) => this.setState({visibility: evt.target.value, currentPage: 1})
-
-  _onClickNewRow = () => this.props.newRowClicked(this.props.table.id)
+  _onClickNewRow = () => this.props.newRowClicked({tableId: this.props.table.id})
 
   _onClickShowTableHelp = () => this.props.showHelpClicked(this.props.table.id)
 
   _onGoToFocus = e => e.target.select()
 
   _onGoToKeyUp = e => {
+    // on press [ENTER], set page to new page number
     if (e.keyCode === 13) {
       const newPage = parseInt(e.target.value)
-      if (newPage > 0 && newPage <= this.state.pageCount) {
+      if (newPage > 0 && newPage <= this.props.pageCount) {
         e.target.value = ''
-        this.setState({ currentPage: newPage })
+        this.props.setCurrentPage({newPage})
       }
     }
   }
 
-  _onClickDeleteRow = (index) => this.props.deleteRowClicked(this.props.table.id, index)
+  _onPageLeft = evt => this.props.setCurrentPage({ newPage: this.props.currentPage - 1 })
 
-  _onPageLeft = evt => this.setState({ currentPage: this.state.currentPage - 1 })
-
-  _onPageRight = evt => this.setState({ currentPage: this.state.currentPage + 1 })
+  _onPageRight = evt => this.props.setCurrentPage({ newPage: this.props.currentPage + 1 })
 
   render () {
-    const {showHelpClicked, table, tableData, validation} = this.props
-    const {currentPage, pageCount} = this.state
-    console.log(currentPage, pageCount, tableData && tableData.length)
-    const rowData = this.getActiveRowData(currentPage)
+    const {currentPage, pageCount, visibility, showHelpClicked, table, rows} = this.props
     const headerStyle = {
       fontWeight: 'bold',
       fontSize: '24px',
@@ -151,9 +110,10 @@ export default class GtfsPlusTable extends Component {
               : null
             }
             <span style={{ fontSize: '18px' }}>
-              Show&nbsp;
+              Show{' '}
               <FormControl
                 componentClass='select'
+                value={visibility}
                 onChange={this._onChangeVisibleRows}>
                 <option value='all'>All Records</option>
                 <option value='validation'>Validation Issues Only</option>
@@ -182,61 +142,23 @@ export default class GtfsPlusTable extends Component {
           </tr>
         </thead>
         <tbody>
-          {rowData && rowData.length > 0
-            ? rowData.map((data, rowIndex) => {
-              const tableRowIndex = ((currentPage - 1) * RECORDS_PER_PAGE) + rowIndex
-              return (
-                <tr key={rowIndex}>
-                  {table.fields.map(field => {
-                    const validationIssue = validation
-                      ? this.props.validation.find(v =>
-                          (v.rowIndex === data.origRowIndex && v.fieldName === field.name))
-                      : null
-
-                    const tooltip = validationIssue ? (
-                      <Tooltip id='validation-tooltip'>{validationIssue.description}</Tooltip>
-                    ) : null
-                    return (
-                      <td key={field.name}>
-                        {validationIssue
-                          ? <div style={{ float: 'left' }}>
-                            <OverlayTrigger placement='top' overlay={tooltip}>
-                              <Glyphicon glyph='alert' style={{ color: 'red', marginTop: '4px' }} />
-                            </OverlayTrigger>
-                          </div>
-                          : null
-                        }
-                        <div style={{ marginLeft: (validationIssue ? '20px' : '0px') }}>
-                          {<GtfsPlusField
-                            {...this.props}
-                            row={tableRowIndex}
-                            field={field}
-                            currentValue={data[field.name]} />}
-                        </div>
-                      </td>
-                    )
-                  })}
-                  <td>
-                    <OptionButton
-                      bsStyle='danger'
-                      bsSize='small'
-                      value={tableRowIndex}
-                      className='pull-right'
-                      onClick={this._onClickDeleteRow}>
-                      <Glyphicon glyph='remove' />
-                    </OptionButton>
-                  </td>
-                </tr>
-              )
-            })
+          {rows && rows.length > 0
+            ? rows
+            .map((data, rowIndex) => (
+              <GtfsPlusRow
+                {...this.props}
+                data={data}
+                key={`${table.id}-${rowIndex}`}
+                index={rowIndex} />
+            ))
             : null
           }
         </tbody>
       </Table>
 
-      {(!tableData || tableData.length === 0)
+      {(!rows || rows.length === 0)
         ? <Row><Col xs={12}>
-          <i>No entries exist for this table.</i>
+          <i>No {visibility === 'validation' ? 'validation issues' : 'entries exist'} for this table.</i>
         </Col></Row>
         : null
       }
@@ -251,5 +173,77 @@ export default class GtfsPlusTable extends Component {
       </Row>
 
     </div>)
+  }
+}
+
+class GtfsPlusRow extends Component {
+  static propTypes = {
+    currentPage: PropTypes.number,
+    data: PropTypes.object,
+    deleteRowClicked: PropTypes.func,
+    index: PropTypes.number,
+    recordsPerPage: PropTypes.number,
+    table: PropTypes.object,
+    validation: PropTypes.array,
+    visibility: PropTypes.string
+  }
+
+  _onClickDeleteRow = (index) => {
+    this.props.deleteRowClicked(this.props.table.id, index)
+  }
+
+  render () {
+    const {data, table, validation} = this.props
+    // // if validation filter is on, do not render issue-free records
+    // if (visibility === 'validation' && validation.length < 5000 && !validation.find(v => v.rowIndex === data.origRowIndex)) {
+    //   return null
+    // }
+    // // filter out rows that are not on current page
+    // if (index > currentPage * recordsPerPage || index < (currentPage - 1) * recordsPerPage) {
+    //   return null
+    // }
+    return (
+      <tr>
+        {table.fields.map(field => {
+          const validationIssue = validation
+            ? validation.find(v =>
+                (v.rowIndex === data.origRowIndex && v.fieldName === field.name))
+            : null
+
+          const tooltip = validationIssue ? (
+            <Tooltip id='validation-tooltip'>{validationIssue.description}</Tooltip>
+          ) : null
+          return (
+            <td key={field.name}>
+              {validationIssue
+                ? <div style={{ float: 'left' }}>
+                  <OverlayTrigger placement='top' overlay={tooltip}>
+                    <Glyphicon glyph='alert' style={{ color: 'red', marginTop: '4px' }} />
+                  </OverlayTrigger>
+                </div>
+                : null
+              }
+              <div style={{ marginLeft: (validationIssue ? '20px' : '0px') }}>
+                {<GtfsPlusField
+                  {...this.props}
+                  row={data.rowIndex}
+                  field={field}
+                  currentValue={data[field.name]} />}
+              </div>
+            </td>
+          )
+        })}
+        <td>
+          <OptionButton
+            bsStyle='danger'
+            bsSize='small'
+            value={data.rowIndex}
+            className='pull-right'
+            onClick={this._onClickDeleteRow}>
+            <Glyphicon glyph='remove' />
+          </OptionButton>
+        </td>
+      </tr>
+    )
   }
 }

--- a/lib/gtfsplus/components/GtfsPlusTable.js
+++ b/lib/gtfsplus/components/GtfsPlusTable.js
@@ -9,7 +9,16 @@ const RECORDS_PER_PAGE = 25
 
 export default class GtfsPlusTable extends Component {
   static propTypes = {
-    table: PropTypes.object
+    table: PropTypes.object,
+    tableData: PropTypes.array,
+    validation: PropTypes.object,
+    newRowClicked: PropTypes.func,
+    deleteRowClicked: PropTypes.func,
+    fieldEdited: PropTypes.func,
+    gtfsEntitySelected: PropTypes.func,
+    getGtfsEntity: PropTypes.func,
+    showHelpClicked: PropTypes.func,
+    newRowsDisplayed: PropTypes.func
   }
 
   state = {
@@ -22,6 +31,19 @@ export default class GtfsPlusTable extends Component {
     if (this.props.table !== nextProps.table) {
       this.setState({ currentPage: 1 })
     }
+    const nextTableLength = nextProps.tableData && nextProps.tableData.length
+    const tableLength = this.props.tableData && this.props.tableData.length
+    if (tableLength !== nextTableLength && nextProps.tableData) {
+      const pageCount = Math.ceil(nextTableLength / RECORDS_PER_PAGE)
+      // If current page becomes greater than page count (e.g., after deleting rows)
+      // or page count increases (e.g., after adding rows), set current page to
+      // page count to avoid confusion for user (user has added a row, but they
+      // don't see it because the current page has not updated).
+      const currentPage = this.state.currentPage > pageCount || pageCount > this.state.pageCount
+        ? pageCount
+        : this.state.currentPage
+      this.setState({currentPage, pageCount})
+    }
   }
 
   componentDidMount () {
@@ -33,17 +55,18 @@ export default class GtfsPlusTable extends Component {
   }
 
   getActiveRowData (currentPage) {
-    if (!this.props.tableData) return []
-    const tableValidation = this.props.validation || []
+    const {tableData, validation} = this.props
+    if (!tableData) return []
+    const tableValidation = validation || []
     if (this.state.visibility === 'validation' && tableValidation.length < 5000) {
-      return this.props.tableData
+      return tableData
         .filter(record => (tableValidation.find(v => v.rowIndex === record.origRowIndex)))
         .slice((currentPage - 1) * RECORDS_PER_PAGE,
-          Math.min(currentPage * RECORDS_PER_PAGE, this.props.tableData.length))
+          Math.min(currentPage * RECORDS_PER_PAGE, tableData.length))
     }
-    return this.props.tableData
+    return tableData
       .slice((currentPage - 1) * RECORDS_PER_PAGE,
-        Math.min(currentPage * RECORDS_PER_PAGE, this.props.tableData.length))
+        Math.min(currentPage * RECORDS_PER_PAGE, tableData.length))
   }
 
   _onChangeVisibleRows = (evt) => this.setState({visibility: evt.target.value, currentPage: 1})
@@ -71,9 +94,10 @@ export default class GtfsPlusTable extends Component {
   _onPageRight = evt => this.setState({ currentPage: this.state.currentPage + 1 })
 
   render () {
-    const {showHelpClicked, table} = this.props
-    const {pageCount} = this.state
-    const rowData = this.getActiveRowData(this.state.currentPage)
+    const {showHelpClicked, table, tableData, validation} = this.props
+    const {currentPage, pageCount} = this.state
+    console.log(currentPage, pageCount, tableData && tableData.length)
+    const rowData = this.getActiveRowData(currentPage)
     const headerStyle = {
       fontWeight: 'bold',
       fontSize: '24px',
@@ -103,15 +127,15 @@ export default class GtfsPlusTable extends Component {
             {(pageCount > 1)
               ? <span style={{ marginRight: '15px' }}>
                 <Button
-                  disabled={this.state.currentPage <= 1}
+                  disabled={currentPage <= 1}
                   onClick={this._onPageLeft}>
                   <Glyphicon glyph='arrow-left' />
                 </Button>
                 <span style={{fontSize: '18px', margin: '0px 10px'}}>
-                  Page {this.state.currentPage} of {pageCount}
+                  Page {currentPage} of {pageCount}
                 </span>
                 <Button
-                  disabled={this.state.currentPage >= pageCount}
+                  disabled={currentPage >= pageCount}
                   onClick={this._onPageRight}>
                   <Glyphicon glyph='arrow-right' />
                 </Button>
@@ -160,11 +184,11 @@ export default class GtfsPlusTable extends Component {
         <tbody>
           {rowData && rowData.length > 0
             ? rowData.map((data, rowIndex) => {
-              const tableRowIndex = ((this.state.currentPage - 1) * RECORDS_PER_PAGE) + rowIndex
+              const tableRowIndex = ((currentPage - 1) * RECORDS_PER_PAGE) + rowIndex
               return (
                 <tr key={rowIndex}>
                   {table.fields.map(field => {
-                    const validationIssue = this.props.validation
+                    const validationIssue = validation
                       ? this.props.validation.find(v =>
                           (v.rowIndex === data.origRowIndex && v.fieldName === field.name))
                       : null
@@ -196,7 +220,7 @@ export default class GtfsPlusTable extends Component {
                     <OptionButton
                       bsStyle='danger'
                       bsSize='small'
-                      value={rowIndex}
+                      value={tableRowIndex}
                       className='pull-right'
                       onClick={this._onClickDeleteRow}>
                       <Glyphicon glyph='remove' />
@@ -210,7 +234,7 @@ export default class GtfsPlusTable extends Component {
         </tbody>
       </Table>
 
-      {!rowData || rowData.length === 0
+      {(!tableData || tableData.length === 0)
         ? <Row><Col xs={12}>
           <i>No entries exist for this table.</i>
         </Col></Row>

--- a/lib/gtfsplus/components/GtfsPlusVersionSummary.js
+++ b/lib/gtfsplus/components/GtfsPlusVersionSummary.js
@@ -3,7 +3,7 @@ import { Panel, Row, Col, Table, Button, Glyphicon, Alert } from 'react-bootstra
 import { browserHistory } from 'react-router'
 import moment from 'moment'
 
-import { getConfigProperty } from '../../common/util/config'
+import { getGtfsPlusSpec } from '../../common/util/config'
 
 export default class GtfsPlusVersionSummary extends Component {
   static propTypes = {
@@ -117,7 +117,7 @@ export default class GtfsPlusVersionSummary extends Component {
                   </tr>
                 </thead>
                 <tbody>
-                  {getConfigProperty('modules.gtfsplus.spec').map((table, index) => {
+                  {getGtfsPlusSpec().map((table, index) => {
                     const issueCount = this.validationIssueCount(table.id)
                     return (
                       <tr

--- a/lib/gtfsplus/containers/ActiveGtfsPlusEditor.js
+++ b/lib/gtfsplus/containers/ActiveGtfsPlusEditor.js
@@ -9,10 +9,15 @@ import {
   uploadGtfsPlusFeed,
   downloadGtfsPlusFeed,
   loadGtfsEntities,
-  receiveGtfsEntities
+  receiveGtfsEntities,
+  setActiveTable,
+  setCurrentPage,
+  setVisibilityFilter
 } from '../actions/gtfsplus'
+import {getVisibleRows, getFilteredPageCount} from '../selectors'
 
 const mapStateToProps = (state, ownProps) => {
+  const {activeTableId, currentPage, gtfsEntityLookup, recordsPerPage, tableData, validation, visibility} = state.gtfsplus
   const feedSourceId = ownProps.routeParams.feedSourceId
   const feedVersionId = ownProps.routeParams.feedVersionId
   const user = state.user
@@ -30,13 +35,19 @@ const mapStateToProps = (state, ownProps) => {
   }
 
   return {
-    tableData: state.gtfsplus.tableData,
-    gtfsEntityLookup: state.gtfsplus.gtfsEntityLookup,
-    validation: state.gtfsplus.validation,
+    activeTableId,
+    currentPage,
     feedSource,
     feedVersionId,
+    gtfsEntityLookup,
+    pageCount: getFilteredPageCount(state),
     project,
-    user
+    recordsPerPage,
+    tableData,
+    user,
+    validation,
+    visibleRows: getVisibleRows(state),
+    visibility
   }
 }
 
@@ -49,9 +60,9 @@ const mapDispatchToProps = (dispatch, ownProps) => {
       if (!initialProps.feedSource) dispatch(fetchFeedSourceAndProject(feedSourceId))
       if (!initialProps.tableData) dispatch(downloadGtfsPlusFeed(feedVersionId))
     },
-    newRowClicked: (tableId) => dispatch(addGtfsPlusRow(tableId)),
+    newRowClicked: (payload) => dispatch(addGtfsPlusRow(payload)),
     deleteRowClicked: (tableId, rowIndex) => dispatch(deleteGtfsPlusRow(tableId, rowIndex)),
-    fieldEdited: (tableId, rowIndex, fieldName, newValue) => dispatch(updateGtfsPlusField(tableId, rowIndex, fieldName, newValue)),
+    fieldEdited: (payload) => dispatch(updateGtfsPlusField(payload)),
     feedSaved: (file) => {
       dispatch(uploadGtfsPlusFeed(feedVersionId, file))
       .then(() => dispatch(downloadGtfsPlusFeed(feedVersionId)))
@@ -59,7 +70,10 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     loadGtfsEntities: (tableId, rows, feedSource, feedVersionId) => {
       if (feedSource) dispatch(loadGtfsEntities(tableId, rows, feedSource, feedVersionId))
     },
-    gtfsEntitySelected: (type, entity) => dispatch(receiveGtfsEntities([entity]))
+    gtfsEntitySelected: (type, entity) => dispatch(receiveGtfsEntities([entity])),
+    setCurrentPage: payload => dispatch(setCurrentPage(payload)),
+    setActiveTable: payload => dispatch(setActiveTable(payload)),
+    setVisibilityFilter: payload => dispatch(setVisibilityFilter(payload))
   }
 }
 

--- a/lib/gtfsplus/containers/ActiveGtfsPlusEditor.js
+++ b/lib/gtfsplus/containers/ActiveGtfsPlusEditor.js
@@ -14,6 +14,7 @@ import {
 
 const mapStateToProps = (state, ownProps) => {
   const feedSourceId = ownProps.routeParams.feedSourceId
+  const feedVersionId = ownProps.routeParams.feedVersionId
   const user = state.user
   // find the containing project
   const project = state.projects.all
@@ -33,6 +34,7 @@ const mapStateToProps = (state, ownProps) => {
     gtfsEntityLookup: state.gtfsplus.gtfsEntityLookup,
     validation: state.gtfsplus.validation,
     feedSource,
+    feedVersionId,
     project,
     user
   }
@@ -54,8 +56,8 @@ const mapDispatchToProps = (dispatch, ownProps) => {
       dispatch(uploadGtfsPlusFeed(feedVersionId, file))
       .then(() => dispatch(downloadGtfsPlusFeed(feedVersionId)))
     },
-    newRowsDisplayed: (tableId, rows, feedSource) => {
-      if (feedSource) dispatch(loadGtfsEntities(tableId, rows, feedSource))
+    loadGtfsEntities: (tableId, rows, feedSource, feedVersionId) => {
+      if (feedSource) dispatch(loadGtfsEntities(tableId, rows, feedSource, feedVersionId))
     },
     gtfsEntitySelected: (type, entity) => dispatch(receiveGtfsEntities([entity]))
   }

--- a/lib/gtfsplus/reducers/gtfsplus.js
+++ b/lib/gtfsplus/reducers/gtfsplus.js
@@ -1,35 +1,40 @@
 import update from 'react-addons-update'
 
-/* const emptyTableData = {
-  'realtime_routes': [],
-  'realtime_stops': [],
-  'directions': [],
-  'realtime_trips': [],
-  'stop_attributes': [],
-  'timepoints': [],
-  'rider_categories': [],
-  'fare_rider_categories': [],
-  'calendar_attributes': [],
-  'farezone_attributes': []
-} */
+import {constructNewGtfsPlusRow} from '../util'
 
-const gtfsplus = (state = {
+const defaultState = {
+  activeTableId: 'realtime_routes',
   feedVersionId: null,
   timestamp: null,
   tableData: null,
   validation: {},
-  gtfsEntityLookup: {}
-}, action) => {
+  gtfsEntityLookup: {},
+  visibility: 'all',
+  currentPage: 1,
+  pageCount: 0,
+  recordsPerPage: 25
+}
+
+const gtfsplus = (state = defaultState, action) => {
   switch (action.type) {
     case 'CLEAR_GTFSPLUS_CONTENT':
-      return {
-        feedVersionId: null,
-        timestamp: null,
-        tableData: null,
-        validation: null,
-        gtfsEntityLookup: {}
-      }
-
+      return defaultState
+    case 'SET_CURRENT_GTFSPLUS_PAGE':
+      return update(state, {
+        currentPage: {$set: action.payload.newPage}
+      })
+    case 'SET_ACTIVE_GTFSPLUS_TABLE':
+      const tableRows = state.tableData[action.payload.activeTableId] || []
+      return update(state, {
+        activeTableId: {$set: action.payload.activeTableId},
+        currentPage: {$set: 1},
+        pageCount: {$set: Math.ceil(tableRows.length / state.recordsPerPage)}
+      })
+    case 'SET_GTFSPLUS_VISIBILITY':
+      return update(state, {
+        visibility: {$set: action.payload.visibility},
+        currentPage: {$set: 1}
+      })
     case 'RECEIVE_GTFSPLUS_CONTENT':
       const newTableData = {}
       for (let i = 0; i < action.filenames.length; i++) {
@@ -43,7 +48,9 @@ const gtfsplus = (state = {
           .filter(line => line.split(COLUMN_REGEX).length === fields.length)
           .map((line, rowIndex) => {
             const values = line.split(COLUMN_REGEX)
-            const rowData = { origRowIndex: rowIndex }
+            // add origRowIndex for referencing validation issues and rowIndex
+            // for use with adding/deleting rows
+            const rowData = { origRowIndex: rowIndex, rowIndex }
             for (let f = 0; f < fields.length; f++) {
               rowData[fields[f]] = values[f]
             }
@@ -53,49 +60,74 @@ const gtfsplus = (state = {
       return update(state, {
         feedVersionId: {$set: action.feedVersionId},
         timestamp: {$set: action.timestamp},
-        tableData: {$set: newTableData}
+        tableData: {$set: newTableData},
+        pageCount: {$set: Math.ceil(newTableData.length / state.recordsPerPage)}
       })
     case 'ADD_GTFSPLUS_ROW':
+      const newRow = constructNewGtfsPlusRow(action.payload.tableId)
+      const tableExists = action.payload.tableId in state.tableData
+      newRow.origRowIndex = tableExists
+        ? state.tableData[state.activeTableId].length
+        : 1
       // create this table if it doesn't already exist
-      if (!(action.tableId in state.tableData)) {
+      if (!tableExists) {
         return update(state,
           {tableData:
-            {$merge: {[action.tableId]: [action.rowData]}}
+            {$merge: {[action.payload.tableId]: [newRow]}}
           }
         )
       }
+      const pageCountPostAdd = Math.ceil((state.tableData[state.activeTableId].length + 1) / state.recordsPerPage)
+      // Anytime a user adds a new row, the expected behavior would be to see that row,
+      // so we set the current page to page count if it is less than the new count
+      const currentPagePostAdd = pageCountPostAdd > state.currentPage
+        ? pageCountPostAdd
+        : state.currentPage
       // otherwise, add it to the exising table
       return update(state, {
         tableData: {
-          [action.tableId]: {
-            $push: [action.rowData]
+          [action.payload.tableId]: {
+            $push: [newRow]
           }
-        }
+        },
+        pageCount: {$set: pageCountPostAdd},
+        currentPage: {$set: currentPagePostAdd}
       })
     case 'UPDATE_GTFSPLUS_FIELD':
       return update(state, {
         tableData: {
-          [action.tableId]: {
-            [action.rowIndex]: {
-              [action.fieldName]: {
-                $set: action.newValue
+          [action.payload.tableId]: {
+            [action.payload.rowIndex]: {
+              [action.payload.fieldName]: {
+                $set: action.payload.newValue
               }
             }
           }
         }
       })
     case 'DELETE_GTFSPLUS_ROW':
-      const table = state.tableData[action.tableId]
+      const deleteTable = state.tableData[action.tableId]
+      // update rowIndex for rows after deleted row (to account for index offset)
+      const recordsAfterDeletedRow = deleteTable.slice(action.rowIndex + 1)
+      recordsAfterDeletedRow.map(r => {
+        r.rowIndex = r.rowIndex - 1
+      })
       const newTable = [
-        ...table.slice(0, action.rowIndex),
-        ...table.slice(action.rowIndex + 1)
+        ...deleteTable.slice(0, action.rowIndex),
+        ...recordsAfterDeletedRow
       ]
+      const pageCountPostDelete = Math.ceil(newTable.length / state.recordsPerPage)
+      const currentPagePostDelete = state.currentPage > pageCountPostDelete
+        ? pageCountPostDelete
+        : state.currentPage
       return update(state, {
         tableData: {
           [action.tableId]: {
             $set: newTable
           }
-        }
+        },
+        pageCount: {$set: pageCountPostDelete},
+        currentPage: {$set: currentPagePostDelete}
       })
     case 'RECEIVE_GTFS_PLUS_ENTITIES':
       const getType = function (entity) {

--- a/lib/gtfsplus/reducers/gtfsplus.js
+++ b/lib/gtfsplus/reducers/gtfsplus.js
@@ -66,7 +66,8 @@ const gtfsplus = (state = defaultState, action) => {
     case 'ADD_GTFSPLUS_ROW':
       const newRow = constructNewGtfsPlusRow(action.payload.tableId)
       const tableExists = action.payload.tableId in state.tableData
-      newRow.origRowIndex = tableExists
+      // add rowIndex for use with tracking row for deletion/updating values
+      newRow.rowIndex = tableExists
         ? state.tableData[state.activeTableId].length
         : 1
       // create this table if it doesn't already exist
@@ -109,6 +110,7 @@ const gtfsplus = (state = defaultState, action) => {
       const deleteTable = state.tableData[action.tableId]
       // update rowIndex for rows after deleted row (to account for index offset)
       const recordsAfterDeletedRow = deleteTable.slice(action.rowIndex + 1)
+      console.log(recordsAfterDeletedRow)
       recordsAfterDeletedRow.map(r => {
         r.rowIndex = r.rowIndex - 1
       })

--- a/lib/gtfsplus/reducers/gtfsplus.js
+++ b/lib/gtfsplus/reducers/gtfsplus.js
@@ -69,7 +69,7 @@ const gtfsplus = (state = defaultState, action) => {
       // add rowIndex for use with tracking row for deletion/updating values
       newRow.rowIndex = tableExists
         ? state.tableData[state.activeTableId].length
-        : 1
+        : 0
       // create this table if it doesn't already exist
       if (!tableExists) {
         return update(state,
@@ -110,7 +110,6 @@ const gtfsplus = (state = defaultState, action) => {
       const deleteTable = state.tableData[action.tableId]
       // update rowIndex for rows after deleted row (to account for index offset)
       const recordsAfterDeletedRow = deleteTable.slice(action.rowIndex + 1)
-      console.log(recordsAfterDeletedRow)
       recordsAfterDeletedRow.map(r => {
         r.rowIndex = r.rowIndex - 1
       })

--- a/lib/gtfsplus/selectors/index.js
+++ b/lib/gtfsplus/selectors/index.js
@@ -3,7 +3,7 @@ import { createSelector } from 'reselect'
 const getActiveTable = createSelector(
   [ state => state.gtfsplus.activeTableId, state => state.gtfsplus.tableData ],
   (tableId, tableData) => {
-    return tableData[tableId]
+    return tableData && tableData[tableId]
   }
 )
 

--- a/lib/gtfsplus/selectors/index.js
+++ b/lib/gtfsplus/selectors/index.js
@@ -1,0 +1,42 @@
+import { createSelector } from 'reselect'
+
+const getActiveTable = createSelector(
+  [ state => state.gtfsplus.activeTableId, state => state.gtfsplus.tableData ],
+  (tableId, tableData) => {
+    return tableData[tableId]
+  }
+)
+
+const getTableValidation = state => state.gtfsplus.validation[state.gtfsplus.activeTableId] || []
+
+export const getFilteredRows = createSelector(
+  [ state => state.gtfsplus.visibility, getActiveTable, getTableValidation ],
+  (visibility, table, validation) => {
+    switch (visibility) {
+      case 'all':
+        return table
+      case 'validation':
+        return table
+          ? table.filter(record => (validation.find(v => v.rowIndex === record.origRowIndex)))
+          : []
+    }
+  }
+)
+
+export const getFilteredPageCount = createSelector(
+  [ state => state.gtfsplus.recordsPerPage, getFilteredRows ],
+  (recordsPerPage, rows) => {
+    const numRows = rows ? rows.length : 0
+    return Math.ceil(numRows / recordsPerPage)
+  }
+)
+
+export const getVisibleRows = createSelector(
+  [ state => state.gtfsplus.currentPage, state => state.gtfsplus.recordsPerPage, getFilteredRows ],
+  (currentPage, recordsPerPage, rows) => {
+    return rows
+      ? rows.slice((currentPage - 1) * recordsPerPage,
+          Math.min(currentPage * recordsPerPage, rows.length))
+      : []
+  }
+)

--- a/lib/gtfsplus/util/index.js
+++ b/lib/gtfsplus/util/index.js
@@ -1,8 +1,13 @@
-import { getConfigProperty } from '../../common/util/config'
+// @flow
 
-export function constructNewGtfsPlusRow (tableId) {
-  const table = getConfigProperty('modules.gtfsplus.spec')
+import {getGtfsPlusSpec} from '../../common/util/config'
+
+export function constructNewGtfsPlusRow (tableId: string): any {
+  const table = getGtfsPlusSpec()
     .find(t => t.id === tableId)
+  if (typeof table === 'undefined') {
+    throw new Error(`Could not find table '${tableId}' in GTFS+ spec`)
+  }
   const rowData = {}
   for (const field of table.fields) {
     rowData[field.name] = null

--- a/lib/gtfsplus/util/index.js
+++ b/lib/gtfsplus/util/index.js
@@ -2,7 +2,7 @@
 
 import {getGtfsPlusSpec} from '../../common/util/config'
 
-export function constructNewGtfsPlusRow (tableId: string): any {
+export function constructNewGtfsPlusRow (tableId: string): { [string]: null } {
   const table = getGtfsPlusSpec()
     .find(t => t.id === tableId)
   if (typeof table === 'undefined') {

--- a/lib/gtfsplus/util/index.js
+++ b/lib/gtfsplus/util/index.js
@@ -1,0 +1,11 @@
+import { getConfigProperty } from '../../common/util/config'
+
+export function constructNewGtfsPlusRow (tableId) {
+  const table = getConfigProperty('modules.gtfsplus.spec')
+    .find(t => t.id === tableId)
+  const rowData = {}
+  for (const field of table.fields) {
+    rowData[field.name] = null
+  }
+  return rowData
+}

--- a/lib/style.css
+++ b/lib/style.css
@@ -201,3 +201,14 @@ h4.line:after {
   max-height: 400px;
   overflow-x: hidden;
 }
+
+
+/* GTFS+ Editor */
+
+.gtfsplus-table-button {
+  display: block;
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/lib/types.js
+++ b/lib/types.js
@@ -204,6 +204,21 @@ export type GtfsFare = {
   transfer_duration: number
 }
 
+export type GtfsPlusField = {
+  name: string,
+  required: boolean,
+  inputType: any,
+  columnWidth: number,
+  helpContent: string
+}
+
+export type GtfsPlusTable = {
+  id: string,
+  name: string,
+  helpContent: string,
+  fields: Array<GtfsPlusField>
+}
+
 export type GtfsRoute = {
   agency?: Agency,
   agency_id: string,

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "cover-flow": "flow-coverage-report -t html -t text -i 'lib/**/*.js' -o coverage-flow",
     "deploy": "mastarm deploy --minify --env production",
     "lint": "mastarm lint \"lib/**/*.js\"",
+    "predeploy": "yarn",
     "prestart": "yarn",
     "start": "mastarm build --serve --proxy http://localhost:4000/api",
     "test": "npm run lint && npm run test-client",


### PR DESCRIPTION
This PR addresses #34.

For each table in the GTFS+ Editor, rows are paginated.  Page settings are managed in the component state right now.  The `pageCount` and `currentPage` state variables where not being updated properly when the number of rows changed.

The other major fix here is to swap out the feed source ID for the feed version ID, when fetching GTFS entities (routes, stops).  Using the feed source ID would return entities from the "published" version, but since the user is editing a specific version that might have different entities than the published version, there may be a mismatch or missing entities.