### PR TITLE
Better keypress behavior in timetable editor

### DIFF
--- a/lib/editor/components/timetable/EditableCell.js
+++ b/lib/editor/components/timetable/EditableCell.js
@@ -4,6 +4,9 @@ import moment from 'moment'
 
 import { TIMETABLE_FORMATS } from '../../util/timetable'
 
+/**
+ * A component to handle the editing of a cell in a timetable editor
+ */
 export default class EditableCell extends Component {
   static propTypes = {
     isEditing: PropTypes.bool
@@ -16,6 +19,10 @@ export default class EditableCell extends Component {
     originalData: this.props.data
   }
 
+  /**
+   * The component may receive data from a save event or
+   * editing can be changed by a change in the activeCell in the TimetableGrid
+   */
   componentWillReceiveProps (nextProps) {
     if (this.props.data !== nextProps.data) {
       this.setState({data: nextProps.data})
@@ -24,6 +31,7 @@ export default class EditableCell extends Component {
       this.setState({isEditing: nextProps.isEditing})
     }
   }
+
   cancel = () => {
     this.setState({
       isEditing: false,
@@ -48,21 +56,33 @@ export default class EditableCell extends Component {
     }
   }
 
+  /**
+   * Depending on the key pressed while focused on a cell, do some special things.
+   */
   handleKeyDown = (evt) => {
     const input = ReactDOM.findDOMNode(this.cellInput)
+    const {
+      duplicateLeft,
+      isFocused,
+      onRight,
+      onRowSelect,
+      onUp,
+      renderTime
+    } = this.props
+    const {isEditing} = this.state
     switch (evt.keyCode) {
       case 88: // x
-        if (this.props.renderTime) {
+        if (renderTime) {
           evt.preventDefault()
-          this.props.onRowSelect(evt)
+          onRowSelect(evt)
           break
         } else {
           return true
         }
       case 79: // o
-        if (this.props.renderTime) {
+        if (renderTime) {
           evt.preventDefault()
-          this.props.onRowSelect(evt)
+          onRowSelect(evt)
           break
         } else {
           return true
@@ -70,20 +90,20 @@ export default class EditableCell extends Component {
       case 222: // single quote
         if (evt.shiftKey) {
           console.log('dupe left')
-          this.props.duplicateLeft && this.props.duplicateLeft(evt)
-          this.props.onRight(evt)
+          duplicateLeft && duplicateLeft(evt)
+          onRight(evt)
           return false
         }
         break
       case 13: // Enter
         evt.preventDefault()
-        if (this.props.isFocused) {
+        if (isFocused) {
           this.beginEditing()
         }
         // handle shift
         if (evt.shiftKey) {
           this.save(evt)
-          this.props.onUp(evt)
+          onUp(evt)
         } else {
           this.save(evt)
         }
@@ -101,6 +121,13 @@ export default class EditableCell extends Component {
         this.cancel()
         break
       case 39: // right
+        // do nothing if cell is being edited
+        if (isEditing) {
+          evt.stopPropagation()
+          return
+        }
+
+        // save and move to next cell if at end of string
         if (input.selectionStart === input.value.length) {
           this.save(evt)
           return false
@@ -108,6 +135,13 @@ export default class EditableCell extends Component {
           return true
         }
       case 37: // left
+        // do nothing if cell is being edited
+        if (isEditing) {
+          evt.stopPropagation()
+          return
+        }
+
+        // save and move to next cell if at start of string
         if (input.selectionStart === 0 && input.selectionEnd === input.value.length) {
           this.save(evt)
           return false

--- a/lib/editor/components/timetable/EditableCell.js
+++ b/lib/editor/components/timetable/EditableCell.js
@@ -206,12 +206,33 @@ export default class EditableCell extends Component {
       // for time rendering
       let data = this.state.data
       // console.log(this.state.data)
-      if (typeof this.state.data !== 'string') return this.cancel()
-      const parts = this.state.data.split(':')
-      const hours = +parts[0]
+      if (typeof data !== 'string') return this.cancel()
+      let hours, parts
+      if (data.indexOf(':') > -1) {
+        // is a string with colons
+        parts = data.split(':')
+        hours = +parts[0]
+      } else {
+        // is a string without colons
+        if (data.length === 3) {
+          // format of `hmm`
+          parts = [data[0], data.substr(1, 3)]
+          hours = +data[0]
+        } else if (data.length === 4) {
+          // format of `HHmm`
+          parts = [data.substr(0, 2), data.substr(2, 4)]
+          hours = +data.substr(0, 2)
+        }
+      }
+
       let greaterThan24 = false
 
       // check for times greater than 24:00
+      // TODO: fix edge case of a stop time being 34 hours or more
+      // realistically this probably wouldn't happen, but a hypothetical
+      // case for this would be an airline flight that leaves at 23:59
+      // and flies for 13 hours before landing.  Another use-case is the
+      // trans-siberian railway that takes 7 days to travel from Moscow to Beijings
       if (parts && parts[0] && hours >= 24 && hours < 34) {
         parts[0] = `0${hours - 24}`
         greaterThan24 = true

--- a/lib/editor/components/timetable/EditableCell.js
+++ b/lib/editor/components/timetable/EditableCell.js
@@ -9,7 +9,8 @@ import { TIMETABLE_FORMATS } from '../../util/timetable'
  */
 export default class EditableCell extends Component {
   static propTypes = {
-    isEditing: PropTypes.bool
+    isEditing: PropTypes.bool,
+    offsetScrollCol: PropTypes.func.isRequired
   }
 
   state = {
@@ -67,7 +68,8 @@ export default class EditableCell extends Component {
       onRight,
       onRowSelect,
       onUp,
-      renderTime
+      renderTime,
+      offsetScrollCol
     } = this.props
     const {isEditing} = this.state
     switch (evt.keyCode) {
@@ -109,19 +111,17 @@ export default class EditableCell extends Component {
         }
         break
       case 9: // Tab
+        // save and advance to next cell if editing
+        this.save()
+        offsetScrollCol(evt.shiftKey ? -1 : 1)
         evt.preventDefault()
-        // handle shift
-        if (evt.shiftKey) {
-          this.save(evt)
-        } else {
-          this.save(evt)
-        }
+        evt.stopPropagation()
         break
       case 27: // Esc
         this.cancel()
         break
       case 39: // right
-        // do nothing if cell is being edited
+        // cancel event propogation if cell is being edited
         if (isEditing) {
           evt.stopPropagation()
           return
@@ -168,6 +168,10 @@ export default class EditableCell extends Component {
   _onOuterKeyDown = (e) => {
     if (document.activeElement === e.target && e.which === 13) {
       this.handleClick(e)
+    } else if (e.keyCode === 9) {
+      this.props.offsetScrollCol(e.shiftKey ? -1 : 1)
+      e.stopPropagation()
+      e.preventDefault()
     }
   }
 
@@ -213,6 +217,7 @@ export default class EditableCell extends Component {
       }
     }
   }
+
   cellRenderer (value) {
     if (this.props.cellRenderer) {
       return this.props.cellRenderer(this.props.column, value)
@@ -311,7 +316,8 @@ export default class EditableCell extends Component {
         onFocus={this._onInputFocus}
         onBlur={this.cancel} />
       : <div
-        style={divStyle}>
+        style={divStyle}
+        >
         {this.cellRenderer(this.state.data)}
       </div>
     return (

--- a/lib/editor/components/timetable/EditableCell.js
+++ b/lib/editor/components/timetable/EditableCell.js
@@ -127,6 +127,9 @@ export default class EditableCell extends Component {
           return
         }
 
+        // update scroll position in TimetableGrid
+        offsetScrollCol(1)
+
         // save and move to next cell if at end of string
         if (input.selectionStart === input.value.length) {
           this.save(evt)
@@ -140,6 +143,9 @@ export default class EditableCell extends Component {
           evt.stopPropagation()
           return
         }
+
+        // update scroll position in TimetableGrid
+        offsetScrollCol(-1)
 
         // save and move to next cell if at start of string
         if (input.selectionStart === 0 && input.selectionEnd === input.value.length) {
@@ -166,12 +172,23 @@ export default class EditableCell extends Component {
   }
 
   _onOuterKeyDown = (e) => {
-    if (document.activeElement === e.target && e.which === 13) {
-      this.handleClick(e)
-    } else if (e.keyCode === 9) {
-      this.props.offsetScrollCol(e.shiftKey ? -1 : 1)
-      e.stopPropagation()
-      e.preventDefault()
+    const {offsetScrollCol} = this.props
+    switch (e.keyCode) {
+      case 9:  // tab
+        // update scroll position in TimetableGrid
+        offsetScrollCol(e.shiftKey ? -1 : 1)
+        // prevent other listeners and default browser tabbing
+        e.stopPropagation()
+        e.preventDefault()
+        break
+      case 37: // left
+        // update scroll position in TimetableGrid
+        offsetScrollCol(-1)
+        break
+      case 39: // right
+        // update scroll position in TimetableGrid
+        offsetScrollCol(1)
+        break
     }
   }
 

--- a/lib/editor/components/timetable/TimetableGrid.js
+++ b/lib/editor/components/timetable/TimetableGrid.js
@@ -40,9 +40,16 @@ export default class TimetableGrid extends Component {
     }
   }
 
+  /**
+   * Handles a keypress event when the Timetable Grid is focused.
+   * This occurs when an EditableCell is not in focus, but the grid is.
+   * Whenever an EditableCell loses focus by an end in editing, the focus should
+   * bubble up to this component.
+   */
   handleKeyPress = (evt) => {
     const {
       activeCell,
+      data,
       setActiveCell,
       scrollToColumn,
       scrollToRow,
@@ -68,6 +75,7 @@ export default class TimetableGrid extends Component {
         evt.preventDefault()
         // override ArrowKeyStepper
         evt.stopPropagation()
+
         // check if done with command key or ctrl
         if (evt.metaKey || evt.ctrlKey) {
           // move all the way to the first column
@@ -75,13 +83,31 @@ export default class TimetableGrid extends Component {
         } else {
           this.offsetScrollCol(-1)
         }
+
+        // retain active focus on the grid
         this._focusOnGrid()
+        break
+      case 38: // up
+        // check if done with command key or ctrl
+        if (evt.metaKey || evt.ctrlKey) {
+          // prevent default up behavior
+          evt.preventDefault()
+          // override ArrowKeyStepper
+          evt.stopPropagation()
+
+          // move all the way to top
+          updateScroll(0, scrollToColumn)
+
+          // retain active focus on the grid
+          this._focusOnGrid()
+        }
         break
       case 39: // right
         // prevent browser back
         evt.preventDefault()
         // override ArrowKeyStepper
         evt.stopPropagation()
+
         // check if done with command key or ctrl
         if (evt.metaKey || evt.ctrlKey) {
           // move all the way to the first column
@@ -89,7 +115,24 @@ export default class TimetableGrid extends Component {
         } else {
           this.offsetScrollCol(1)
         }
+
+        // retain active focus on the grid
         this._focusOnGrid()
+        break
+      case 40: // down
+        // check if done with command key or ctrl
+        if (evt.metaKey || evt.ctrlKey) {
+          // prevent default up behavior
+          evt.preventDefault()
+          // override ArrowKeyStepper
+          evt.stopPropagation()
+
+          // move all the way to the bottom
+          updateScroll(data.length - 1, scrollToColumn)
+
+          // retain active focus on the grid
+          this._focusOnGrid()
+        }
         break
       case 67:
         // handle copy

--- a/lib/editor/components/timetable/TimetableGrid.js
+++ b/lib/editor/components/timetable/TimetableGrid.js
@@ -231,7 +231,7 @@ export default class TimetableGrid extends Component {
     )
   }
 
-  _getColumnCount() {
+  _getColumnCount () {
     const {columns, hideDepartureTimes} = this.props
     return hideDepartureTimes ? getHeaderColumns(columns).length : columns.length
   }

--- a/lib/editor/components/timetable/TimetableGrid.js
+++ b/lib/editor/components/timetable/TimetableGrid.js
@@ -7,7 +7,23 @@ import objectPath from 'object-path'
 
 import HeaderCell from './HeaderCell'
 import EditableCell from './EditableCell'
-import {getCellRenderer, getHeaderColumns, isTimeFormat, parseTime, OVERSCAN_ROW_COUNT, OVERSCAN_COLUMN_COUNT, HEADER_GRID_WRAPPER_STYLE, HEADER_GRID_STYLE, LEFT_GRID_WRAPPER_STYLE, LEFT_COLUMN_WIDTH, ROW_HEIGHT, LEFT_GRID_STYLE, TOP_LEFT_STYLE, MAIN_GRID_WRAPPER_STYLE, WRAPPER_STYLE} from '../../util/timetable'
+import {
+  getCellRenderer,
+  getHeaderColumns,
+  isTimeFormat,
+  parseTime,
+  OVERSCAN_ROW_COUNT,
+  OVERSCAN_COLUMN_COUNT,
+  HEADER_GRID_WRAPPER_STYLE,
+  HEADER_GRID_STYLE,
+  LEFT_GRID_WRAPPER_STYLE,
+  LEFT_COLUMN_WIDTH,
+  ROW_HEIGHT,
+  LEFT_GRID_STYLE,
+  TOP_LEFT_STYLE,
+  MAIN_GRID_WRAPPER_STYLE,
+  WRAPPER_STYLE
+} from '../../util/timetable'
 
 export default class TimetableGrid extends Component {
   static propTypes = {
@@ -169,7 +185,9 @@ export default class TimetableGrid extends Component {
         rowIndex={rowIndex}
         style={style}
         onStopEditing={this.handleEndEditing}
-        onChange={this._onCellChange} />
+        onChange={this._onCellChange}
+        offsetScrollCol={this.offsetScrollCol}
+        />
     )
   }
 
@@ -200,9 +218,27 @@ export default class TimetableGrid extends Component {
       : 90
   }
 
+  /**
+   * A helper method to move the active column a certain amount of cells left or right.
+   * This was initially added to help with handling tab and shift + tab events.
+   * @param {number} offset the number of columns to offset, can be positive or negative
+   */
+  offsetScrollCol = (offset) => {
+    const {scrollToColumn, scrollToRow, updateScroll} = this.props
+    updateScroll(
+      scrollToRow,
+      Math.max(Math.min(scrollToColumn + offset, this._getColumnCount() - 1), 0)
+    )
+  }
+
+  _getColumnCount() {
+    const {columns, hideDepartureTimes} = this.props
+    return hideDepartureTimes ? getHeaderColumns(columns).length : columns.length
+  }
+
   render () {
     const {onScroll, scrollLeft, scrollTop, onSectionRendered, scrollToColumn, scrollToRow} = this.props
-    const {style, data, columns, hideDepartureTimes, selected} = this.props
+    const {style, data, columns, selected} = this.props
     const selectAll = selected.length === data.length
     const columnHeaderCount = getHeaderColumns(columns).length
     return (
@@ -267,7 +303,7 @@ export default class TimetableGrid extends Component {
                     ref={Grid => { this.grid = Grid }}
                     style={{outline: 'none'}}
                     columnWidth={this._getColumnWidth}
-                    columnCount={hideDepartureTimes ? columnHeaderCount : columns.length}
+                    columnCount={this._getColumnCount()}
                     height={height}
                     onScroll={onScroll}
                     overscanColumnCount={OVERSCAN_COLUMN_COUNT}

--- a/lib/editor/components/timetable/TimetableGrid.js
+++ b/lib/editor/components/timetable/TimetableGrid.js
@@ -41,7 +41,13 @@ export default class TimetableGrid extends Component {
   }
 
   handleKeyPress = (evt) => {
-    const {activeCell, setActiveCell, scrollToColumn, scrollToRow} = this.props
+    const {
+      activeCell,
+      setActiveCell,
+      scrollToColumn,
+      scrollToRow,
+      updateScroll
+    } = this.props
     switch (evt.keyCode) {
       case 8: // DELETE
         // TODO: add delete cell value
@@ -57,6 +63,34 @@ export default class TimetableGrid extends Component {
         } else {
           return setActiveCell(null)
         }
+      case 37: // left
+        // prevent browser back
+        evt.preventDefault()
+        // override ArrowKeyStepper
+        evt.stopPropagation()
+        // check if done with command key or ctrl
+        if (evt.metaKey || evt.ctrlKey) {
+          // move all the way to the first column
+          updateScroll(scrollToRow, 0)
+        } else {
+          this.offsetScrollCol(-1)
+        }
+        this._focusOnGrid()
+        break
+      case 39: // right
+        // prevent browser back
+        evt.preventDefault()
+        // override ArrowKeyStepper
+        evt.stopPropagation()
+        // check if done with command key or ctrl
+        if (evt.metaKey || evt.ctrlKey) {
+          // move all the way to the first column
+          updateScroll(scrollToRow, this._getColumnCount() - 1)
+        } else {
+          this.offsetScrollCol(1)
+        }
+        this._focusOnGrid()
+        break
       case 67:
         // handle copy
         if (evt.ctrlKey) {
@@ -207,6 +241,10 @@ export default class TimetableGrid extends Component {
   handleEndEditing = () => {
     this.props.setActiveCell(null)
     // refocus on grid after editing is done
+    this._focusOnGrid()
+  }
+
+  _focusOnGrid () {
     ReactDOM.findDOMNode(this.grid) && ReactDOM.findDOMNode(this.grid).focus()
   }
 

--- a/lib/editor/components/timetable/TimetableGrid.js
+++ b/lib/editor/components/timetable/TimetableGrid.js
@@ -43,16 +43,20 @@ export default class TimetableGrid extends Component {
   handleKeyPress = (evt) => {
     const {activeCell, setActiveCell, scrollToColumn, scrollToRow} = this.props
     switch (evt.keyCode) {
+      case 8: // DELETE
+        // TODO: add delete cell value
+        // updateCellValue('', rowIndex, `${scrollToRow}.${col.key}`)
+        break
+      case 9:  // tab
+        this.offsetScrollCol(evt.shiftKey ? -1 : 1)
+        evt.preventDefault()
+        break
       case 13: // Enter
         if (!activeCell) {
           return setActiveCell(`${scrollToRow}-${scrollToColumn}`)
         } else {
           return setActiveCell(null)
         }
-      case 8: // DELETE
-        // TODO: add delete cell value
-        // updateCellValue('', rowIndex, `${scrollToRow}.${col.key}`)
-        break
       case 67:
         // handle copy
         if (evt.ctrlKey) {
@@ -166,27 +170,26 @@ export default class TimetableGrid extends Component {
     const isInvalid = isTimeFormat(col.type) && val >= 0 && val < previousValue && val !== null
     return (
       <EditableCell
-        key={key}
-        onClick={updateScroll}
-        // duplicateLeft={(evt) => updateCellValue(previousValue, rowIndex, `${rowIndex}.${col.key}`)}
-        handlePastedRows={this.handlePastedRows}
-        invalidData={isInvalid}
-        isEditing={isEditing}
-        isSelected={rowIsChecked}
-        isFocused={isFocused}
-        hideDepartureTimes={hideDepartureTimes}
-        lightText={col.type === 'DEPARTURE_TIME'}
-        placeholder={col.placeholder}
-        renderTime={isTimeFormat(col.type)}
         cellRenderer={getCellRenderer}
-        data={val}
         column={col}
         columnIndex={columnIndex} // pass original index to prevent issues with updateScroll/scrollsync
+        data={val}
+        handlePastedRows={this.handlePastedRows}
+        hideDepartureTimes={hideDepartureTimes}
+        invalidData={isInvalid}
+        isEditing={isEditing}
+        isFocused={isFocused}
+        isSelected={rowIsChecked}
+        key={key}
+        lightText={col.type === 'DEPARTURE_TIME'}
+        offsetScrollCol={this.offsetScrollCol}
+        onChange={this._onCellChange}
+        onClick={updateScroll}
+        onStopEditing={this.handleEndEditing}
+        placeholder={col.placeholder}
+        renderTime={isTimeFormat(col.type)}
         rowIndex={rowIndex}
         style={style}
-        onStopEditing={this.handleEndEditing}
-        onChange={this._onCellChange}
-        offsetScrollCol={this.offsetScrollCol}
         />
     )
   }


### PR DESCRIPTION
* Don’t jump to another cell if the left or right key is pressed while a
cell is in edit mode.
* Allow tab and shift tab to move to the right or left cell respectively
* Allow 24+ hour time input in the format "HHmm"
* Allow ctrl/cmd + right/left to move to horizontal end or beginning of sheet
* Allow ctrl/cmd + up/down to move to vertical end or beginning of sheet