### PR TITLE
Fix null stoptime in timetable trip sorter

### DIFF
--- a/lib/editor/util/index.js
+++ b/lib/editor/util/index.js
@@ -134,12 +134,22 @@ export function sortAndFilterTrips (
     ? trips
         .filter(t => t.useFrequency === useFrequency) // filter out based on useFrequency
         .sort((a, b) => {
-          if (!a.stopTimes[0].departureTime || !b.stopTimes[0].departureTime) {
+          // There may be a case where a null value (skipped stop) appears first
+          // in the list of stopTimes. In this case, we want to compare on the
+          // first stopTime that exists for each pair of trips.
+          let aStopTime, bStopTime
+          let count = 0
+          while (!aStopTime || !bStopTime) {
+            aStopTime = a.stopTimes[count]
+            bStopTime = b.stopTimes[count]
+            count++
+          }
+          if (!aStopTime.departureTime || !bStopTime.departureTime) {
             return 0
-          } else if (a.stopTimes[0].departureTime < b.stopTimes[0].departureTime) {
+          } else if (aStopTime.departureTime < bStopTime.departureTime) {
             return -1
           } else if (
-            a.stopTimes[0].departureTime > b.stopTimes[0].departureTime
+            aStopTime.departureTime > bStopTime.departureTime
           ) {
             return 1
           }


### PR DESCRIPTION
The first stopTime for a trip was being used to sort the trips returned from the server. When that
stopTime was null, the sorter was failing. This fix iterates over the stopTimes for each pair of
trips until it finds one that exists for each pair and then it sorts on that index.

fixes catalogueglobal/datatools-server#48