### PR TITLE
Allow editing of null stop times

### DIFF
--- a/lib/editor/components/timetable/TimetableGrid.js
+++ b/lib/editor/components/timetable/TimetableGrid.js
@@ -271,8 +271,43 @@ export default class TimetableGrid extends Component {
     )
   }
 
+  /**
+   * Handle a change in the value of a cell.
+   *
+   * This function gets called with a post-processed value from the `save`
+   * method of EditableCell.  The value can be a time value or non-time entry
+   * such as Trip Id or Headsign.
+   */
   _onCellChange = (value, rowIndex, col, colIndex) => {
-    const {columns, hideDepartureTimes, updateCellValue} = this.props
+    const {
+      activePattern,
+      columns,
+      data,
+      hideDepartureTimes,
+      updateCellValue
+    } = this.props
+
+    // determine if the value is a time entry
+    if (isTimeFormat(col.type)) {
+      // make sure stop time isn't null
+      const splitColKeys = col.key.split('.')
+      const stopTimeIdx = splitColKeys[1]
+      const trip = data[rowIndex]
+      const stopTime = trip.stopTimes[stopTimeIdx]
+      if (!stopTime) {
+        // stop time is null.  Create new stop time
+
+        // get stop id from pattern
+        const {stopId} = activePattern.patternStops[stopTimeIdx]
+
+        // create filler stop time object
+        updateCellValue(
+          { stopId },
+          rowIndex,
+          `${rowIndex}.stopTimes.${stopTimeIdx}`
+        )
+      }
+    }
     updateCellValue(value, rowIndex, `${rowIndex}.${col.key}`)
     // if departure times are hidden, set departure time value equal to arrival time
     const nextCol = columns[colIndex + 1]


### PR DESCRIPTION
This change allows a user to edit a null stop time given the current methodology.  In a previous version, when a user inserted a stop into a pattern all trips would have null stop times in the datastore for that inserted stop.  This causes issues in the UI that were partially addressed by #42.  However, there were still problems when said null stop time was attempted to be edited.  There was an undefined error that occurred when trying to perform this edit thus making it impossible to edit.  To fix this, I have added code that checks whether the stop time about to be edited is null or not.  If it is null, the new code inserts a stop-time object with the correct stop id.  Then any further edits can take place without issues.