### PR TITLE
build(semantic-release): fix git url to point to catalogueglobal repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Core application for the Conveyal transit data tools suite",
   "repository": {
     "type": "git",
-    "url": "https://github.com/conveyal/datatools-ui.git"
+    "url": "https://github.com/catalogueglobal/datatools-ui.git"
   },
   "author": "Conveyal LLC",
   "license": "MIT",


### PR DESCRIPTION
Fix git URL so semantic-release does not push tagged releases to conveyal/datatools-ui.