### PR TITLE
Bug fix for semantic-release build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Core application for the Conveyal transit data tools suite",
   "repository": {
     "type": "git",
-    "url": "https://github.com/conveyal/datatools-ui.git"
+    "url": "https://github.com/catalogueglobal/datatools-ui.git"
   },
   "author": "Conveyal LLC",
   "license": "MIT",


### PR DESCRIPTION
Refs #51.  Changing repo URL so semantic-release pushes tagged release to correct repo.