### PR TITLE
Fix graphql spec

### DIFF
--- a/lib/gtfs/actions/feed.js
+++ b/lib/gtfs/actions/feed.js
@@ -45,7 +45,7 @@ export function fetchFeed (namespace, date, from, to) {
         return response.json()
       })
       .then(json => {
-        dispatch(receiveFeed(namespace, json))
+        dispatch(receiveFeed(namespace, json.data))
       })
   }
 }

--- a/lib/gtfs/actions/general.js
+++ b/lib/gtfs/actions/general.js
@@ -76,12 +76,15 @@ export function fetchStopsAndRoutes (entities, module) {
     const method = 'post'
     const body = JSON.stringify({
       query: stopsAndRoutes(feedId, routeId, stopId),
-      variables: JSON.stringify({feedId, routeId, stopId})
+      variables: {feedId, routeId, stopId}
     })
     dispatch(requestStopsAndRoutes(feedId, routeId, stopId, module))
     return fetch(GTFS_GRAPHQL_PREFIX, {method, body})
       .then(response => response.json())
-      .then(results => dispatch(receivedStopsAndRoutes(results, module)))
+      .then(results => {
+        const stopsAndRoutes = results.data
+        dispatch(receivedStopsAndRoutes(stopsAndRoutes, module))
+      })
   }
 }
 
@@ -106,7 +109,9 @@ export function refreshGtfsElements (feedId, entities) {
         return response.json()
       })
       .then(results => {
-        return dispatch(receivedGtfsElements(feedId, results.stops, results.patterns))
+        const patterns = results.data.patterns
+        const stops = results.data.stops
+        return dispatch(receivedGtfsElements(feedId, stops, patterns))
       })
   }
 }

--- a/lib/gtfs/actions/patterns.js
+++ b/lib/gtfs/actions/patterns.js
@@ -32,8 +32,8 @@ export function fetchPatterns (namespace, routeId, date, from, to) {
         return response.json()
       })
       .then(json => {
-        if (json && json.feed) {
-          const {routes} = json.feed
+        if (json && json.data && json.data.feed) {
+          const {routes} = json.data.feed
           dispatch(receivePatterns({namespace, routes}))
         } else {
           console.log('Error fetching patterns')

--- a/lib/gtfs/actions/routes.js
+++ b/lib/gtfs/actions/routes.js
@@ -15,7 +15,7 @@ export function fetchRoutes (namespace) {
         return response.json()
       })
       .then(json => {
-        const {routes} = json.feed
+        const {routes} = json.data.feed
         dispatch(receiveRoutes({namespace, routes}))
       })
   }

--- a/lib/gtfs/actions/stops.js
+++ b/lib/gtfs/actions/stops.js
@@ -61,7 +61,8 @@ export function fetchStopsWithFilters (feedId) {
         return response.json()
       })
       .then(json => {
-        dispatch(receiveStops(feedId, routeId, patternId, json))
+        const stops = json.data
+        dispatch(receiveStops(feedId, routeId, patternId, stops))
       })
   }
 }
@@ -74,7 +75,8 @@ export function fetchStops (feedId, routeId, patternId, date, from, to) {
         return response.json()
       })
       .then(json => {
-        dispatch(receiveStops(feedId, routeId, patternId, json))
+        const stops = json.data
+        dispatch(receiveStops(feedId, routeId, patternId, stops))
       })
   }
 }

--- a/lib/manager/actions/versions.js
+++ b/lib/manager/actions/versions.js
@@ -236,12 +236,16 @@ export function fetchGTFSEntities ({feedVersion, id, type}) {
     dispatch(fetchingGTFSEntities({feedVersion, id, type}))
     return fetchGraphQL({query, variables: {namespace, [entityIdField]: id}})
       .then(response => response.json())
-      .then(data => dispatch(receiveGTFSEntities({feedVersion, id, type, data})))
+      .then(data => {
+        const entities = data.data
+        dispatch(receiveGTFSEntities({feedVersion, id, type, entities}))
+      })
       .catch(err => console.log(err))
   }
 }
 
 export function fetchValidationErrors ({feedVersion, errorType, limit, offset}) {
+  console.log(feedVersion)
   return function (dispatch, getState) {
     dispatch(fetchingValidationErrors({feedVersion, errorType, limit, offset}))
     // FIXME: why does namespace need to appear twice?
@@ -266,8 +270,8 @@ export function fetchValidationErrors ({feedVersion, errorType, limit, offset}) 
     return fetchGraphQL({query, variables: {namespace, errorType: [errorType], limit, offset}})
     .then(response => response.json())
     .then(result => {
-      if (result.feed) {
-        const {errors} = result.feed
+      if (result.data.feed) {
+        const {errors} = result.data.feed
         dispatch(receiveValidationErrors({feedVersion, errorType, limit, offset, errors}))
       }
     })
@@ -278,7 +282,7 @@ export function fetchValidationErrors ({feedVersion, errorType, limit, offset}) 
 function fetchGraphQL ({query, variables, ...requestParams}) {
   const body = JSON.stringify({
     query,
-    variables: JSON.stringify(variables)
+    variables: variables
   })
   return fetch(GTFS_GRAPHQL_PREFIX, {
     method: 'post',
@@ -313,8 +317,8 @@ export function fetchValidationResult (feedVersion, isPublic) {
     return fetchGraphQL({query, variables: {namespace}})
     .then(response => response.json())
     .then(result => {
-      if (result.feed) {
-        dispatch(receiveValidationResult(feedVersion, result.feed))
+      if (result.data.feed) {
+        dispatch(receiveValidationResult(feedVersion, result.data.feed))
       }
     })
     .catch(err => console.log(err))

--- a/scripts/seedData.js
+++ b/scripts/seedData.js
@@ -146,10 +146,10 @@ async function makeGraphQLRequests (feedVersionId) {
       method,
       body: JSON.stringify({
         query: GRAPHQL_STOPS_QUERY,
-        variables: JSON.stringify({namespace})
+        variables: {namespace}
       })
     })
-    .then(res => res.json())
+    .then(res => res.json().data)
     // .then(json => {
     //   // console.log(`graphql response: ${JSON.stringify(json)}`)
     //


### PR DESCRIPTION
Use normalized graphql.
It would be better to use a graphql client so we can use cache and lot
of other things offered by graphql.

I'm not sure i covered everything, this needs testing.