### PR TITLE
Corrected app_metadata and user_metadata retrieval.

### DIFF
--- a/lib/common/user/Auth0Manager.js
+++ b/lib/common/user/Auth0Manager.js
@@ -29,6 +29,7 @@ class Auth0Manager {
         this.lockOptions || {
           allowSignUp: false,
           auth: {
+            responseType: 'token id_token',
             params: {
               scope: 'app_metadata profile email openid user_metadata'
             },
@@ -36,6 +37,7 @@ class Auth0Manager {
           },
           autoclose: true,
           closable: true,
+          oidcConformant: true,
           languageDictionary: {
             title: getMessage(getComponentMessages('Login'), 'title')
           },

--- a/lib/manager/actions/user.js
+++ b/lib/manager/actions/user.js
@@ -91,6 +91,8 @@ export function receiveTokenAndProfile (authResult) {
   }
 
   const {token, profile} = authResult
+  profile.app_metadata = profile['http://catalogue/app_metadata']
+  profile.user_metadata = profile['http://catalogue/user_metadata']
   return userLoggedIn({
     token,
     profile,


### PR DESCRIPTION
`app_metadata` and `user_metadata` can't be returned by the userinfo endpoint any more ([unless you signed paid for Auth0 before 1st September 2017](https://auth0.com/docs/metadata)). This pull request and the following Auth0 rule corrects this:

```
function (user, context, callback) {
  var namespace = 'http://catalogue/';
   if (context.idToken && user.user_metadata) {
     context.idToken[namespace + 'user_metadata'] = user.user_metadata;
   }
   if (context.idToken && user.app_metadata) {
     context.idToken[namespace + 'app_metadata'] = user.app_metadata;
   }
   callback(null, user, context);
}
```