### PR TITLE
Add missing shape ID to pattern on save

### DIFF
--- a/lib/editor/actions/tripPattern.js
+++ b/lib/editor/actions/tripPattern.js
@@ -2,6 +2,7 @@ import {createAction} from 'redux-actions'
 import {snakeCaseKeys} from '../../common/util/map-keys'
 
 import {secureFetch} from '../../common/actions'
+import {generateUID} from '../../common/util/util'
 import {fetchGTFSEntities} from '../../manager/actions/versions'
 import {resetActiveGtfsEntity, savedGtfsEntity, updateActiveGtfsEntity, updateEditSetting} from './active'
 import {fetchTripCounts} from './trip'
@@ -74,6 +75,13 @@ export function saveTripPattern (feedId, tripPattern) {
     // NOTE: This must be applied before snake case-ing (because
     // resequenceShapePoints updates the camelCase field shapePtSequence).
     tripPattern.patternStops = tripPattern.patternStops.map(resequenceStops)
+    if (!tripPattern.shapeId) {
+      // If trip pattern has no shape ID (e.g., if the pattern was imported
+      // without shapes), generate one and assign shape points to the new ID.
+      const shapeId = generateUID()
+      tripPattern.shapeId = shapeId
+      tripPattern.shapePoints = tripPattern.shapePoints.map(sp => ({...sp, shapeId}))
+    }
     tripPattern.shapePoints = tripPattern.shapePoints.map(resequenceShapePoints)
     const data = snakeCaseKeys(tripPattern)
     // Shape points must be assigned to shapes field in order to match back end


### PR DESCRIPTION
This resolves #208 by simply generating a new shape ID if the pattern does not have one assigned to it. The newly generated shape ID is then assigned to all shape points before saving to the server.