### PR TITLE
Fix Auth0 Safari bug

### DIFF
--- a/lib/common/user/Auth0Manager.js
+++ b/lib/common/user/Auth0Manager.js
@@ -32,7 +32,11 @@ class Auth0Manager {
             params: {
               scope: 'app_metadata profile email openid user_metadata'
             },
-            redirect: false
+            redirect: false,
+            // Provide redirect URL in order to make cross-origin /authorize
+            // request happy. (See https://github.com/catalogueglobal/datatools-ui/issues/226)
+            redirectUrl: window.location.origin,
+            responseType: 'token'
           },
           autoclose: true,
           closable: true,


### PR DESCRIPTION
This PR fixes #226 by adding additional options to the Auth0 lock. It seems a little hacky and that perhaps it shouldn't work, but all it took to make the request succeed was adding a `redirectUrl` (even though `redirect=false` and specifying the `responseType` to token ([otherwise it would default to code](https://auth0.com/docs/libraries/lock/v11/configuration#responsetype-string-)).