### PR TITLE
test(flow): fix flow type for newControlPoint method

### DIFF
--- a/lib/editor/util/map.js
+++ b/lib/editor/util/map.js
@@ -94,8 +94,14 @@ export function isValidPoint (point: any) {
 
 export function newControlPoint (
   distance: ?number,
-  point: Coordinate,
-  props: any = {}
+  point: GeoJsonPoint,
+  props: {
+    shapePtSequence?: number,
+    shapePtLat?: number,
+    shapePtLon?: number,
+    pointType?: number,
+    id?: string | number
+  } = {}
 ): ControlPoint {
   if (!distance && distance !== 0) {
     throw new Error(
@@ -801,7 +807,7 @@ export function generateControlPointsFromPatternStops (
     }
     controlPoints.push(newControlPoint(
       cumulativeDistance,
-      stopPoint.geometry.coordinates,
+      stopPoint,
       {
         id: i,
         stopId: patternStops[i].stopId,
@@ -851,7 +857,7 @@ export function controlPointsFromSegments (
       console.log('coordinate -->', coordinate)
       throw new Error(`Coordinate in segment index ${i}/${patternSegments.length} does not exist`)
     }
-    const controlPoint = newControlPoint(cumulativeDistance, coordinate,
+    const controlPoint = newControlPoint(cumulativeDistance, point(coordinate),
       {
         id: i,
         pointType: POINT_TYPE.STOP,


### PR DESCRIPTION
Changes `point` arg in `newControlPoint` from type `Coordinate` to `GeoJsonPoint`.