### PR TITLE
Fix app_metadata and user_metadata

### DIFF
--- a/lib/common/user/Auth0Manager.js
+++ b/lib/common/user/Auth0Manager.js
@@ -1,6 +1,7 @@
 // @flow
 
 import auth0 from 'auth0-js'
+import fetch from 'isomorphic-fetch'
 import Auth0Lock from 'auth0-lock'
 import {browserHistory} from 'react-router'
 import decode from 'jwt-decode'
@@ -37,7 +38,8 @@ class Auth0Manager {
           allowSignUp: false,
           auth: {
             params: { scope: DEFAULT_SCOPE },
-            redirect: false
+            redirect: false,
+            responseType: 'token id_token'
           },
           autoclose: true,
           closable: true,
@@ -56,35 +58,25 @@ class Auth0Manager {
   }
 
   /**
-   * Use the access token (token for API calls) to get the user's profile.
-   * We can't fetch the profile data all the time because we'll get 429'ed by
-   * Auth0.  Therfore, we also store the profile data in localStorage, but we
-   * assume that the profile data is only valid for 60 seconds since it is
-   * possible that the profile data could have changed since we last logged in.
+   * Use the id token to get the user's profile from the Data Tools server.
+   * This previously used the Auth0 Lock's getUserInfo method, but the client
+   * needs access to the app_metadata and user_metadata, which for new Auth0
+   * tenants should be assigned to the idToken via a rule ().
    *
-   * @param  {String} accessToken auth0 access token
+   * @param  {String} idToken auth0 id token
    * @return {Object}             auth0 profile
    */
-  _getProfileFromToken (accessToken: string): Promise<any> {
+  _getProfileFromToken (idToken: string): Promise<any> {
     return new Promise((resolve, reject) => {
-      const profile = getProfile()
-      if (
-        profile &&
-        profile.accessToken === accessToken &&
-        profile.dataExpirationTimestamp > (new Date()).getTime()
-      ) {
-        return resolve(profile)
+      const headers: {[string]: string} = {
+        'Authorization': `Bearer ${idToken}`,
+        'Accept': 'application/json'
       }
-      this.getLock().getUserInfo(accessToken, (err, profile) => {
-        if (err) reject(err)
-        else {
-          profile.accessToken = accessToken
-          // set data expiration timestamp to be 60 seconds into the future
-          profile.dataExpirationTimestamp = (new Date()).getTime() + 60000
-          setProfile(profile)
-          resolve(profile)
-        }
-      })
+      fetch('/api/manager/secure/user', {headers})
+        // Catch basic error during fetch
+        .catch(err => reject(err))
+        .then(res => res.json())
+        .then(profile => resolve(profile))
     })
   }
 
@@ -191,7 +183,7 @@ class Auth0Manager {
     setAccessToken(accessToken)
     setIdToken(idToken)
     // Get profile with access token and return profile and ID token to store.
-    return this._getProfileFromToken(accessToken)
+    return this._getProfileFromToken(idToken)
       .then(profile => {
         const actions = [
           receiveTokenAndProfile({
@@ -276,7 +268,7 @@ class Auth0Manager {
         if (!accessToken) return logout(userIsLoggedIn)
 
         // try to get the profile from localStorage
-        return this._getProfileFromToken(accessToken)
+        return this._getProfileFromToken(idToken)
           .then((profile) => {
             this.isTryingToGetProfileFromToken = false
             return receiveTokenAndProfile({
@@ -320,14 +312,6 @@ function getAccessToken () {
  */
 function getIdToken () {
   return window.localStorage.getItem('idToken')
-}
-
-/**
- * Get the profile from localStorage and parse it.
- * @return {Object}
- */
-function getProfile (): ?Object {
-  return JSON.parse(window.localStorage.getItem('profile'))
 }
 
 /**
@@ -404,10 +388,6 @@ function setAccessToken (token: string) {
  */
 function setIdToken (token: string) {
   window.localStorage.setItem('idToken', token)
-}
-
-function setProfile (profile: Object) {
-  window.localStorage.setItem('profile', JSON.stringify(profile))
 }
 
 /**

--- a/lib/manager/actions/user.js
+++ b/lib/manager/actions/user.js
@@ -138,8 +138,10 @@ export function receiveTokenAndProfile (authResult: {token: string, profile: Use
   if (!authResult) {
     return logout()
   }
-
   const {token, profile} = authResult
+  if (!profile.app_metadata) {
+    throw new Error('Auth0 not configured properly. Could not locate app_metadata in user profile.')
+  }
   return userLoggedIn({
     token,
     profile,


### PR DESCRIPTION
This (in conjunction with changes in datatools-server) allows new Auth0 tenants to work with Data
Tools. Instead of fetching the user profile from Auth0, we fetch it directly from the
datatools-server API. The server decodes the JWT token into the user profile and re-maps certain
fields (e.g., the scoped app_metadata and the user_id fields) to keys the front end expects.

fixes #207