### PR TITLE
Chart curtailment

### DIFF
--- a/lib/manager/components/validation/ServicePerModeChart.js
+++ b/lib/manager/components/validation/ServicePerModeChart.js
@@ -24,7 +24,8 @@ export default class ServicePerModeChart extends Component<Props> {
     const hasRail = dailyRailSeconds.filter(s => s > 0).length > 0
     let hasOther = false
     const data = []
-    for (let i = 0; i < dailyTotalSeconds.length; i++) {
+    const limit = Math.min(dailyTotalSeconds.length, maxDaysToShow)
+    for (let i = 0; i < limit; i++) {
       const column = {}
       column.date = firstDate.clone().add(i, 'days')
       let other = dailyTotalSeconds[i]
@@ -84,6 +85,7 @@ export default class ServicePerModeChart extends Component<Props> {
     for (let i = yAxisPeriod; i <= yAxisMax; i += yAxisPeriod) {
       yAxisLabels.push(i)
     }
+    const curtailed = maxDaysToShow < validationResult.dailyTotalSeconds.length
     return (
       <div
         className='text-center'
@@ -174,8 +176,15 @@ export default class ServicePerModeChart extends Component<Props> {
               </text>
             </g>
           ))}
+          {curtailed &&
+            <text x={100 * modes.length} y={graphHeight + 43}>
+              * only first 500 days of service shown
+            </text>
+          }
         </svg>
       </div>
     )
   }
 }
+
+const maxDaysToShow = 500

--- a/lib/manager/components/validation/ServicePerModeChart.js
+++ b/lib/manager/components/validation/ServicePerModeChart.js
@@ -14,6 +14,8 @@ type Props = {
   validationResult: ValidationResult
 }
 
+const maxDaysToShow = 500
+
 export default class ServicePerModeChart extends Component<Props> {
   _getData = (validationResult: ValidationResult) => {
     const {dailyBusSeconds, dailyTramSeconds, dailyMetroSeconds, dailyRailSeconds, dailyTotalSeconds, firstCalendarDate} = validationResult
@@ -186,5 +188,3 @@ export default class ServicePerModeChart extends Component<Props> {
     )
   }
 }
-
-const maxDaysToShow = 500

--- a/lib/manager/components/validation/TripsChart.js
+++ b/lib/manager/components/validation/TripsChart.js
@@ -27,8 +27,9 @@ export default class TripsChart extends Component<Props> {
     }
     const {dailyTripCounts, firstCalendarDate} = validationResult
     const firstDate = moment(firstCalendarDate)
-    const data = dailyTripCounts.map((count, index) =>
-      [firstDate.clone().add(index, 'days'), count])
+    const data = dailyTripCounts
+      .slice(0, maxDaysToShow)
+      .map((count, index) => [firstDate.clone().add(index, 'days'), count])
     const graphHeight = 300
     const spacing = 8
     const leftMargin = 50
@@ -43,6 +44,7 @@ export default class TripsChart extends Component<Props> {
     for (var i = yAxisPeriod; i <= yAxisMax; i += yAxisPeriod) {
       yAxisLabels.push(i)
     }
+    const curtailed = maxDaysToShow < dailyTripCounts.length
     return (
       <div
         className='text-center'
@@ -123,8 +125,15 @@ export default class TripsChart extends Component<Props> {
               </text>
             </g>
           ))}
+          {curtailed &&
+            <text x={100 * Object.keys(COLORS).length} y={graphHeight + 43}>
+              * only first 500 days of service shown
+            </text>
+          }
         </svg>
       </div>
     )
   }
 }
+
+const maxDaysToShow = 500

--- a/lib/manager/components/validation/TripsChart.js
+++ b/lib/manager/components/validation/TripsChart.js
@@ -18,6 +18,7 @@ const COLORS = {
   SATURDAY: '#66c2a5',
   SUNDAY: '#fc8d62'
 }
+const maxDaysToShow = 500
 
 export default class TripsChart extends Component<Props> {
   render () {
@@ -135,5 +136,3 @@ export default class TripsChart extends Component<Props> {
     )
   }
 }
-
-const maxDaysToShow = 500


### PR DESCRIPTION
Only show first 500 days of service in TripsChart and ServicePerModeChart components.  This is to avoid drawing an excessive amount of elements in feeds that are valid for excessively long periods of time.