### PR TITLE
Fix app_metadata and user_metadata for new Auth0 clients

### DIFF
--- a/docs/dev/deployment.md
+++ b/docs/dev/deployment.md
@@ -86,6 +86,7 @@ MONGO_DB_NAME: application_db
 ```
 
 ### Setting up Auth0
+Auth0 is used for authentication in the application. If you don't need authentication (e.g., if you're running locally or on a secured network), you can set `DISABLE_AUTH` to true for both the server and UI configurations (`env.yml`).
 
 #### Creating account and application (client)
 1. Create an [Auth0](https://auth0.com) account (free).
@@ -132,10 +133,13 @@ AUTH0_DOMAIN: your-auth0-domain.auth.com
 AUTH0_CLIENT_ID: your-auth0-client-id
 ```
 
-Update the following properties in `datatools-server` `env.yml` to reflect the secure Auth0 application settings:
+Update the following properties in `datatools-server` `env.yml` to reflect the secure Auth0 application settings.
+
+**Note:** for older Auth0 accounts/tenants, it is possible to use the Auth0 secret token, which uses the HS256 algorithm, but newer Auth0 tenants will need to specify the absolute path of their `.pem` file in the `AUTH0_PUBLIC_KEY` property. This public key only needs to be downloaded one time for your Auth0 tenant at `https://[your_domain].auth0.com/pem`.
 
 ```yaml
-AUTH0_SECRET: your-auth0-client-secret
+AUTH0_SECRET: your-auth0-client-secret # used for pre-September 2017 Auth0 accounts
+AUTH0_PUBLIC_KEY: /location/of/auth0-account.pem # used for post-September 2017 Auth0 accounts
 AUTH0_TOKEN: your-auth0-api-token
 ```
 
@@ -149,6 +153,24 @@ To allow for the creation, deletion and editing of users you must generate a tok
     - read, update, create and delete
 - **users_app_metadata**:
     - read, update, create and delete`
+
+#### Auth0 Rule Configuration: making app_metadata and user_metadata visible via token (only required for "new" Auth0 accounts/tenants)
+If using OIDC-conformant clients/APIs (which appears to be mandatory for new Auth0 tenants), you must set up a custom Auth0 rule to add app_metadata and user_metadata to the user's token (Note: this is not the default for older, "legacy" Auth0 accounts). Go to Rules > Create Rule > empty rule and add the following code snippet. If you'd like the rule to only apply to certain clients, you can keep the conditional block that checks for `context.clientID` value. Otherwise, this conditional block is unnecessary.
+
+```
+function (user, context, callback) {
+  if (context.clientID === 'YOUR_CLIENT_ID') {
+    var namespace = 'http://datatools/';
+    if (context.idToken && user.user_metadata) {
+      context.idToken[namespace + 'user_metadata'] = user.user_metadata;
+    }
+    if (context.idToken && user.app_metadata) {
+      context.idToken[namespace + 'app_metadata'] = user.app_metadata;
+    }
+  }
+  callback(null, user, context);
+}
+```
 
 ## Building and Running the Application
 

--- a/lib/common/user/Auth0Manager.js
+++ b/lib/common/user/Auth0Manager.js
@@ -37,7 +37,8 @@ class Auth0Manager {
           allowSignUp: false,
           auth: {
             params: { scope: DEFAULT_SCOPE },
-            redirect: false
+            redirect: false,
+            responseType: 'token id_token'
           },
           autoclose: true,
           closable: true,

--- a/lib/manager/actions/user.js
+++ b/lib/manager/actions/user.js
@@ -165,7 +165,18 @@ export function receiveTokenAndProfile (authResult: {profile: UserProfile, token
     return logout()
   }
 
-  const {token, profile} = authResult
+  const { token, profile } = authResult
+  if (!profile.app_metadata) {
+    // If app_metadata field is not available, look for app_metadata in scoped
+    // fields from Auth0 token. More information on setting up a rule to provide
+    // this scoped field can be found at https://community.auth0.com/t/how-can-i-make-app-metadata-available-in-userinfo-endpoint/6664/4
+    if (profile['http://datatools/app_metadata']) {
+      profile.app_metadata = profile['http://datatools/app_metadata']
+      profile.user_metadata = profile['http://datatools/user_metadata']
+    } else {
+      throw new Error('Auth0 user authentication is not configured properly!')
+    }
+  }
   return userLoggedIn({
     token,
     profile,

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -633,7 +633,8 @@ export type UserProfile = {
   nickname: string,
   picture: string,
   user_id: string,
-  user_metadata: any
+  user_metadata: any,
+  [scopedMetadataFields: string]: any
 }
 
 export type User = {


### PR DESCRIPTION
This (in conjunction with changes at https://github.com/catalogueglobal/datatools-server/pull/113) allows new Auth0 tenants to work with Data
Tools. Instead of fetching the user profile from Auth0, we fetch it directly from the
datatools-server API. The server decodes the JWT token into the user profile and re-maps certain
fields (e.g., the scoped app_metadata and the user_id fields) to keys the front end expects.

fixes #207