### PR TITLE
Add route_sort_order field to route in gtfs spec

### DIFF
--- a/gtfs.yml
+++ b/gtfs.yml
@@ -276,6 +276,11 @@
       text: Funicular
     columnWidth: 12
     helpContent: The route_type field describes the type of transportation used on a route. Valid values for this field are...
+  - name: route_sort_order
+    required: false
+    inputType: POSITIVE_INT
+    columnWidth: 12
+    helpContent: The route_sort_order field can be used to order the routes in a way which is ideal for presentation to customers. It must be a non-negative integer. Routes with smaller route_sort_order values should be displayed before routes with larger route_sort_order values.
   - name: route_url
     required: false
     inputType: URL
@@ -319,11 +324,6 @@
     inputType: URL
     columnWidth: 12
     helpContent:
-  - name: route_sort_order
-    required: false
-    inputType: NUMBER
-    columnWidth: 6
-    helpContent: The route_sort_order field can be used to order the routes in a way which is ideal for presentation to customers. It must be a non-negative integer. Routes with smaller route_sort_order values should be displayed before routes with larger route_sort_order values.
 
 - id: trip
   name: trips.txt

--- a/gtfs.yml
+++ b/gtfs.yml
@@ -319,6 +319,11 @@
     inputType: URL
     columnWidth: 12
     helpContent:
+  - name: "route_sort_order"
+    required: false
+    inputType: NUMBER
+    columnWidth: 6
+    helpContent: "The route_sort_order field can be used to order the routes in a way which is ideal for presentation to customers. It must be a non-negative integer. Routes with smaller route_sort_order values should be displayed before routes with larger route_sort_order values."
 
 - id: trip
   name: trips.txt

--- a/gtfs.yml
+++ b/gtfs.yml
@@ -319,11 +319,11 @@
     inputType: URL
     columnWidth: 12
     helpContent:
-  - name: "route_sort_order"
+  - name: route_sort_order
     required: false
     inputType: NUMBER
     columnWidth: 6
-    helpContent: "The route_sort_order field can be used to order the routes in a way which is ideal for presentation to customers. It must be a non-negative integer. Routes with smaller route_sort_order values should be displayed before routes with larger route_sort_order values."
+    helpContent: The route_sort_order field can be used to order the routes in a way which is ideal for presentation to customers. It must be a non-negative integer. Routes with smaller route_sort_order values should be displayed before routes with larger route_sort_order values.
 
 - id: trip
   name: trips.txt

--- a/gtfs.yml
+++ b/gtfs.yml
@@ -274,12 +274,12 @@
       text: Gondola
     - value: 7
       text: Funicular
-    columnWidth: 12
+    columnWidth: 6
     helpContent: The route_type field describes the type of transportation used on a route. Valid values for this field are...
   - name: route_sort_order
     required: false
     inputType: POSITIVE_INT
-    columnWidth: 12
+    columnWidth: 6
     helpContent: The route_sort_order field can be used to order the routes in a way which is ideal for presentation to customers. It must be a non-negative integer. Routes with smaller route_sort_order values should be displayed before routes with larger route_sort_order values.
   - name: route_url
     required: false

--- a/lib/editor/actions/trip.js
+++ b/lib/editor/actions/trip.js
@@ -60,7 +60,11 @@ export const toggleRowSelection = createAction(
 )
 export const updateCellValue = createAction(
   'UPDATE_TIMETABLE_CELL_VALUE',
-  (payload: { key: string, rowIndex: number, value: string }) => payload
+  (payload: {
+    key: string,
+    rowIndex: number,
+    value: ?(number | string | { stopId: string })
+  }) => payload
 )
 
 export type EditorTripActions = ActionType<typeof addNewTrip> |
@@ -194,7 +198,7 @@ export function saveNewTrip (
     trip.id = null
     return dispatch(secureFetch(url, 'post', trip))
       .then(res => res.json())
-      .then(t => dispatch(addNewTrip(t)))
+      .then((t: any) => dispatch(addNewTrip(t)))
   }
 }
 

--- a/lib/editor/components/EditorInput.js
+++ b/lib/editor/components/EditorInput.js
@@ -18,7 +18,8 @@ import LanguageSelect from '../../common/components/LanguageSelect'
 import toSentenceCase from '../../common/util/to-sentence-case'
 import ZoneSelect from './ZoneSelect'
 
-import type {EditorTableData, Entity, Feed, Field, GtfsAgency, GtfsStop} from '../../types'
+import type {Entity, Feed, Field, GtfsAgency, GtfsStop} from '../../types'
+import type {EditorTables} from '../../types/reducers'
 
 type Props = {
   activeComponent: string,
@@ -30,7 +31,7 @@ type Props = {
   hasRoutes: boolean,
   isNotValid: boolean,
   table: any,
-  tableData: EditorTableData,
+  tableData: EditorTables,
   updateActiveGtfsEntity: typeof updateActiveGtfsEntity,
   uploadBrandingAsset: (string, number, string, File) => void,
   zoneOptions: Array<any>

--- a/lib/editor/components/EntityDetails.js
+++ b/lib/editor/components/EntityDetails.js
@@ -13,8 +13,8 @@ import ScheduleExceptionForm from './ScheduleExceptionForm'
 import { getZones, getEditorTable, canApproveGtfs } from '../util'
 import { getTableById } from '../util/gtfs'
 
-import type {EditorTableData, Entity, Feed, Field, Pattern, Project} from '../../types'
-import type {ManagerUserState, MapState} from '../../types/reducers'
+import type {Entity, Feed, Field, Pattern, Project} from '../../types'
+import type {EditorTables, ManagerUserState, MapState} from '../../types/reducers'
 import type {EditorValidationIssue} from '../util/validation'
 
 type Props = {
@@ -37,7 +37,7 @@ type Props = {
   showConfirmModal: any,
   subComponent: string,
   subEntity: number,
-  tableData: EditorTableData,
+  tableData: EditorTables,
   updateActiveGtfsEntity: typeof updateActiveGtfsEntity,
   updateMapSetting: ({bounds?: any, target?: number, zoom?: number}) => void,
   uploadBrandingAsset: (string, number, string, File) => void,

--- a/lib/editor/components/FareRuleSelections.js
+++ b/lib/editor/components/FareRuleSelections.js
@@ -7,7 +7,8 @@ import VirtualizedEntitySelect from './VirtualizedEntitySelect'
 import {getEntityName, getTableById} from '../util/gtfs'
 import ZoneSelect from './ZoneSelect'
 
-import type {EditorTableData, GtfsFare, GtfsRoute, ZoneOption, Zones, FareRule} from '../../types'
+import type {GtfsFare, GtfsRoute, ZoneOption, Zones, FareRule} from '../../types'
+import type {EditorTables} from '../../types/reducers'
 import type {EntityOption} from './VirtualizedEntitySelect'
 
 type EditableRuleFields = $Keys<$Diff<FareRule, {fare_id: string, id: number}>>
@@ -21,7 +22,7 @@ type Props = {
   showDestinationId: boolean,
   showOriginId: boolean,
   showRouteId: boolean,
-  tableData: EditorTableData,
+  tableData: EditorTables,
   updateActiveGtfsEntity: typeof updateActiveGtfsEntity,
   zoneOptions: Array<ZoneOption>,
   zones: Zones

--- a/lib/editor/components/FareRulesForm.js
+++ b/lib/editor/components/FareRulesForm.js
@@ -9,14 +9,15 @@ import {getFareRuleFieldName} from '../util'
 import FareRuleSelections from './FareRuleSelections'
 import {generateNullProps, getTableById} from '../util/gtfs'
 
-import type {EditorTableData, FareRule, GtfsFare, ZoneOption, Zones} from '../../types'
+import type {FareRule, GtfsFare, ZoneOption, Zones} from '../../types'
+import type {EditorTables} from '../../types/reducers'
 import type {EditorValidationIssue} from '../util/validation'
 
 type Props = {
   activeComponent: string,
   activeEntity: GtfsFare,
   entityEdited: boolean,
-  tableData: EditorTableData,
+  tableData: EditorTables,
   updateActiveGtfsEntity: typeof updateActiveGtfsEntity,
   validationErrors: Array<EditorValidationIssue>,
   zoneOptions: Array<ZoneOption>,

--- a/lib/editor/components/GtfsEditor.js
+++ b/lib/editor/components/GtfsEditor.js
@@ -22,7 +22,6 @@ import {GTFS_ICONS} from '../util/ui'
 import type {
   ControlPoint,
   Coordinates,
-  EditorTableData,
   Entity,
   Feed,
   FeedInfo,
@@ -36,6 +35,7 @@ import type {
 import type {
   EditSettingsState,
   EditorStatus,
+  EditorTables,
   ManagerUserState,
   MapState
 } from '../../types/reducers'
@@ -111,7 +111,7 @@ type Props = {
   subEntity: number,
   subEntityId: number,
   subSubComponent: string,
-  tableData: EditorTableData,
+  tableData: EditorTables,
   timetableStatus: FetchStatus, // fetchStatus
   tripPatterns: Array<Pattern>,
   updateActiveGtfsEntity: typeof updateActiveGtfsEntity,

--- a/lib/editor/components/HourMinuteInput.js
+++ b/lib/editor/components/HourMinuteInput.js
@@ -9,7 +9,7 @@ import {
 } from '../../common/util/date-time'
 
 type Props = {
-  onChange: (any) => void,
+  onChange: (any) => any,
   seconds: number,
   style: {[string]: string | number}
 }

--- a/lib/editor/components/ScheduleExceptionForm.js
+++ b/lib/editor/components/ScheduleExceptionForm.js
@@ -17,13 +17,14 @@ import ExceptionDate from './ExceptionDate'
 import {EXCEPTION_EXEMPLARS} from '../util'
 import {getTableById} from '../util/gtfs'
 
-import type {EditorTableData, ServiceCalendar, ScheduleException} from '../../types'
+import type {ServiceCalendar, ScheduleException} from '../../types'
+import type {EditorTables} from '../../types/reducers'
 import type {EditorValidationIssue} from '../util/validation'
 
 type Props = {
   activeComponent: string,
   activeEntity: ScheduleException,
-  tableData: EditorTableData,
+  tableData: EditorTables,
   updateActiveGtfsEntity: typeof updateActiveGtfsEntity,
   validationErrors: Array<EditorValidationIssue>
 }

--- a/lib/editor/components/timetable/EditableCell.js
+++ b/lib/editor/components/timetable/EditableCell.js
@@ -3,6 +3,7 @@
 import React, {Component} from 'react'
 import moment from 'moment'
 
+import * as tripActions from '../../actions/trip'
 import { TIMETABLE_FORMATS } from '../../util/timetable'
 
 import type {TimetableColumn} from '../../../types'
@@ -28,7 +29,7 @@ type Props = {
   placeholder: ?string,
   renderTime: boolean,
   rowIndex: number,
-  setActiveCell: string => void,
+  setActiveCell: typeof tripActions.setActiveCell,
   style: {[string]: string | number}
 }
 

--- a/lib/editor/components/timetable/HeaderCell.js
+++ b/lib/editor/components/timetable/HeaderCell.js
@@ -2,11 +2,17 @@
 
 import React, {Component} from 'react'
 
+import * as tripActions from '../../actions/trip'
+
+// can't do this inline down below, so they are separated out here
+type toggleAllRowsActionType = typeof tripActions.toggleAllRows
+type toggleRowSelectionActionType = typeof tripActions.toggleRowSelection
+
 type Props = {
   active: boolean,
   index: number,
   label: string,
-  onChange?: ({active: boolean, rowIndex: number}) => void,
+  onChange?: toggleAllRowsActionType | toggleRowSelectionActionType,
   selectable?: boolean,
   style: {[string]: number | string},
   title?: string

--- a/lib/editor/components/timetable/PatternSelect.js
+++ b/lib/editor/components/timetable/PatternSelect.js
@@ -5,8 +5,9 @@ import React, {Component} from 'react'
 import {Label} from 'react-bootstrap'
 import Select from 'react-select'
 
-import {getEntityName} from '../../util/gtfs'
+import * as tripActions from '../../actions/trip'
 import {ENTITY} from '../../constants'
+import {getEntityName} from '../../util/gtfs'
 
 import type {Pattern, GtfsRoute, ServiceCalendar, Feed, TripCounts} from '../../../types'
 
@@ -20,7 +21,7 @@ type PatternOption = {
 type Props = {
   activePattern: Pattern,
   feedSource: Feed,
-  fetchCalendarTripCountsForPattern: (string, string) => void,
+  fetchCalendarTripCountsForPattern: typeof tripActions.fetchCalendarTripCountsForPattern,
   route: GtfsRoute,
   setActiveEntity: (string, string, GtfsRoute, ?string, ?Pattern, ?string, ?ServiceCalendar) => void,
   tripCounts: TripCounts

--- a/lib/editor/components/timetable/Timetable.js
+++ b/lib/editor/components/timetable/Timetable.js
@@ -5,8 +5,9 @@ import {Button} from 'react-bootstrap'
 import {ArrowKeyStepper} from 'react-virtualized/dist/commonjs/ArrowKeyStepper'
 import {ScrollSync} from 'react-virtualized/dist/commonjs/ScrollSync'
 
-import TimetableGrid from './TimetableGrid'
+import * as tripActions from '../../actions/trip'
 import Loading from '../../../common/components/Loading'
+import TimetableGrid from './TimetableGrid'
 import {getHeaderColumns, isTimeFormat} from '../../util/timetable'
 
 import type {Pattern, TimetableColumn, Trip} from '../../../types'
@@ -26,15 +27,15 @@ type Props = {
   saveEditedTrips: (Pattern, string) => void,
   scrollToColumn: number,
   scrollToRow: number,
-  setActiveCell: ?string => void,
-  setOffset: number => void,
-  setScrollIndexes: ({scrollToColumn: number, scrollToRow: number}) => void,
+  setActiveCell: typeof tripActions.setActiveCell,
+  setOffset: typeof tripActions.setOffset,
+  setScrollIndexes: typeof tripActions.setScrollIndexes,
   showHelpModal: () => void,
   style: {[string]: number | string},
   timetable: TimetableState,
-  toggleAllRows: ({active: boolean}) => void,
-  toggleRowSelection: ({active: boolean, rowIndex: number}) => void,
-  updateCellValue: ({key: string, rowIndex: number, value: any}) => void
+  toggleAllRows: typeof tripActions.toggleAllRows,
+  toggleRowSelection: typeof tripActions.toggleRowSelection,
+  updateCellValue: typeof tripActions.updateCellValue
 }
 
 export default class Timetable extends Component<Props> {

--- a/lib/editor/components/timetable/TimetableEditor.js
+++ b/lib/editor/components/timetable/TimetableEditor.js
@@ -6,6 +6,7 @@ import objectPath from 'object-path'
 import React, {Component} from 'react'
 import {Button} from 'react-bootstrap'
 
+import * as tripActions from '../../actions/trip'
 import {ENTITY} from '../../constants'
 import {generateNullProps} from '../../util/gtfs'
 import {entityIsNew} from '../../util/objects'
@@ -15,39 +16,38 @@ import TimetableHeader from './TimetableHeader'
 import TimetableHelpModal from './TimetableHelpModal'
 
 import type {Feed, FetchStatus, GtfsRoute, Pattern, StopTime, TimetableColumn, Trip, TripCounts} from '../../../types'
-import type {TimetableState} from '../../../types/reducers'
+import type {EditorTables, TimetableState} from '../../../types/reducers'
 
 type Props = {
-  activeCell: ?string,
+  activeCell?: ?string,
   activePattern: Pattern,
   activePatternId: number,
   activeSchedule: string,
   activeScheduleId: string,
-  addNewTrip: any => void,
-  columns: Array<TimetableColumn>,
-  data: Array<Trip>,
-  deleteTripsForCalendar: (string, Pattern, string, Array<Trip>) => void,
-  duplicateRows: () => void,
+  addNewTrip: typeof tripActions.addNewTrip,
+  columns?: Array<TimetableColumn>,
+  data?: Array<Trip>,
+  deleteTripsForCalendar: typeof tripActions.deleteTripsForCalendar,
   feedSource: Feed,
-  fetchCalendarTripCountsForPattern: () => void,
-  fetchTripsForCalendar: (string, Pattern, string) => void,
-  offsetRows: ({offset: number, rowIndexes: Array<any>}) => void,
-  removeTrips: Array<any> => void,
+  fetchCalendarTripCountsForPattern: typeof tripActions.fetchCalendarTripCountsForPattern,
+  fetchTripsForCalendar: typeof tripActions.fetchTripsForCalendar,
+  offsetRows: typeof tripActions.offsetRows,
+  removeTrips: typeof tripActions.removeTrips,
   route: GtfsRoute,
-  saveTripsForCalendar: (string, Pattern, string, Array<Trip>) => void,
-  setActiveCell: ?string => void,
+  saveTripsForCalendar: typeof tripActions.saveTripsForCalendar,
+  setActiveCell: typeof tripActions.setActiveCell,
   setActiveEntity: (string, string, any) => void,
-  setOffset: number => void,
-  setScrollIndexes: {scrollToColumn: number, scrollToRow: number} => void,
+  setOffset: typeof tripActions.setOffset,
+  setScrollIndexes: typeof tripActions.setScrollIndexes,
   showConfirmModal: any => void,
-  tableData: any,
+  tableData: EditorTables,
   timetable: TimetableState,
   timetableStatus: FetchStatus,
-  toggleAllRows: {active: boolean} => void,
-  toggleDepartureTimes: () => void,
-  toggleRowSelection: () => void,
+  toggleAllRows: typeof tripActions.toggleAllRows,
+  toggleDepartureTimes: typeof tripActions.toggleDepartureTimes,
+  toggleRowSelection: typeof tripActions.toggleRowSelection,
   tripCounts: TripCounts,
-  updateCellValue: ({key: string, rowIndex: number, value: any}) => void
+  updateCellValue: typeof tripActions.updateCellValue
 }
 
 type State = {

--- a/lib/editor/components/timetable/TimetableGrid.js
+++ b/lib/editor/components/timetable/TimetableGrid.js
@@ -9,6 +9,8 @@ import {Grid} from 'react-virtualized/dist/commonjs/Grid'
 import scrollbarSize from 'dom-helpers/util/scrollbarSize'
 import objectPath from 'object-path'
 
+import * as tripActions from '../../actions/trip'
+import {ENTITY} from '../../constants'
 import HeaderCell from './HeaderCell'
 import EditableCell from './EditableCell'
 import {
@@ -28,7 +30,6 @@ import {
   MAIN_GRID_WRAPPER_STYLE,
   WRAPPER_STYLE
 } from '../../util/timetable'
-import {ENTITY} from '../../constants'
 
 import type {Pattern, TimetableColumn} from '../../../types'
 import type {TimetableState} from '../../../types/reducers'
@@ -54,14 +55,14 @@ type Props = {
   scrollToRow: number,
   scrollTop: number,
   selected: Array<number>,
-  setActiveCell: ?string => void,
-  setOffset: number => void,
+  setActiveCell: typeof tripActions.setActiveCell,
+  setOffset: typeof tripActions.setOffset,
   showHelpModal: () => void,
   style: Style,
   timetable: TimetableState,
-  toggleAllRows: ({active: boolean}) => void,
-  toggleRowSelection: ({active: boolean, rowIndex: number}) => void,
-  updateCellValue: ({key: string, rowIndex: number, value: any}) => void,
+  toggleAllRows: typeof tripActions.toggleAllRows,
+  toggleRowSelection: typeof tripActions.toggleRowSelection,
+  updateCellValue: typeof tripActions.updateCellValue,
   updateScroll: (number, number) => void
 }
 

--- a/lib/editor/components/timetable/TimetableHeader.js
+++ b/lib/editor/components/timetable/TimetableHeader.js
@@ -17,34 +17,34 @@ import {
 } from 'react-bootstrap'
 import truncate from 'truncate'
 
+import * as tripActions from '../../actions/trip'
 import HourMinuteInput from '../HourMinuteInput'
 import CalendarSelect from './CalendarSelect'
 import RouteSelect from './RouteSelect'
 import PatternSelect from './PatternSelect'
 import {getTableById} from '../../util/gtfs'
 
-import type {EditorTableData, Feed, GtfsRoute, Pattern, ServiceCalendar, TripCounts} from '../../../types'
-import type {TimetableState} from '../../../types/reducers'
+import type {Feed, GtfsRoute, Pattern, ServiceCalendar, TripCounts} from '../../../types'
+import type {EditorTables, TimetableState} from '../../../types/reducers'
 
 type Props = {
   activePattern: Pattern,
   activeScheduleId: string,
   addNewRow: (?boolean, ?boolean) => void,
   cloneSelectedTrips: () => void,
-  duplicateRows: () => void,
   feedSource: Feed,
-  fetchCalendarTripCountsForPattern: () => void,
-  fetchTripsForCalendar: (string, Pattern, string) => void,
+  fetchCalendarTripCountsForPattern: typeof tripActions.fetchCalendarTripCountsForPattern,
+  fetchTripsForCalendar: typeof tripActions.fetchTripsForCalendar,
   offsetWithDefaults: (boolean) => void,
   removeSelectedRows: () => void,
   route: GtfsRoute,
   saveEditedTrips: (Pattern, string) => void,
   setActiveEntity: (string, string, GtfsRoute, ?string, ?Pattern, ?string, ?ServiceCalendar) => void,
-  setOffset: number => void,
+  setOffset: typeof tripActions.setOffset,
   showHelpModal: () => void,
-  tableData: EditorTableData,
+  tableData: EditorTables,
   timetable: TimetableState,
-  toggleDepartureTimes: () => void,
+  toggleDepartureTimes: typeof tripActions.toggleDepartureTimes,
   tripCounts: TripCounts
 }
 

--- a/lib/editor/containers/ActiveTimetableEditor.js
+++ b/lib/editor/containers/ActiveTimetableEditor.js
@@ -1,27 +1,31 @@
+// @flow
+
 import { connect } from 'react-redux'
+
 import {
-  saveTripsForCalendar,
+  addNewTrip,
   deleteTripsForCalendar,
   fetchCalendarTripCountsForPattern,
   offsetRows,
-  updateCellValue,
+  removeTrips,
+  // saveNewTrip,
+  saveTripsForCalendar,
   setActiveCell,
+  setOffset,
   setScrollIndexes,
-  toggleRowSelection,
   toggleAllRows,
   toggleDepartureTimes,
-  addNewTrip,
-  // saveNewTrip,
-  removeTrips,
-  setOffset
+  toggleRowSelection,
+  updateCellValue
 } from '../actions/trip'
-
 import TimetableEditor from '../components/timetable/TimetableEditor'
 import {getTableById} from '../util/gtfs'
 import {getTripCounts} from '../selectors'
 import {getTimetableColumns} from '../selectors/timetable'
 
-const mapStateToProps = (state, ownProps) => {
+import type {AppState} from '../../types/reducers'
+
+const mapStateToProps = (state: AppState, ownProps: {}) => {
   const {active, tables} = state.editor.data
   const {
     subEntityId: activePatternId,
@@ -29,7 +33,9 @@ const mapStateToProps = (state, ownProps) => {
   } = active
   const {timetable} = state.editor
   const tripCounts = getTripCounts(state)
+  // $FlowFixMe seems like reselect flow-typed library should work, but it doesn't
   const columns = getTimetableColumns(state)
+  // $FlowFixMe TODO: write comment what this code is doing
   timetable.columns = columns
   const {subEntity: activePattern} = active
   const activeSchedule = getTableById(tables, 'calendar')
@@ -39,6 +45,7 @@ const mapStateToProps = (state, ownProps) => {
     activeScheduleId,
     activePattern,
     activeSchedule,
+    tableData: tables,
     timetable,
     tripCounts
   }

--- a/lib/editor/selectors/index.js
+++ b/lib/editor/selectors/index.js
@@ -66,8 +66,7 @@ export const getValidationErrors: AppState => Array<EditorValidationIssue> = cre
     const errors = table && entity
       ? table.fields
         .map((field, colIndex) =>
-          // $FlowFixMe
-          validate(field, entity[field.name], entities, entity, tableData)
+          validate(field, entity ? entity[field.name] : null, entities, entity, tableData)
         )
         .filter(e => e)
       : []

--- a/lib/editor/util/__tests__/validation.js
+++ b/lib/editor/util/__tests__/validation.js
@@ -46,6 +46,12 @@ describe('editor > util > gtfs >', () => {
         })
       })
 
+      it('empty string should be valid for optional field', () => {
+        expect(
+          validate(routeSortOrderField, '', null, null, defaultTablesData)
+        ).toEqual(false)
+      })
+
       it('string with alphanumeric characters should be invalid', () => {
         expect(
           validate(stopSequenceField, 'abcd123', null, null, defaultTablesData)

--- a/lib/editor/util/__tests__/validation.js
+++ b/lib/editor/util/__tests__/validation.js
@@ -1,0 +1,130 @@
+// @flow
+
+import {defaultState as defaultEditorDataState} from '../../reducers/data'
+import {validate} from '../validation'
+
+const defaultTablesData = defaultEditorDataState.tables
+const routeSortOrderField = {
+  columnWidth: 12,
+  inputType: 'POSITIVE_INT',
+  name: 'route_sort_order',
+  required: false
+}
+const shapedDistTraveledField = {
+  columnWidth: 6,
+  inputType: 'POSITIVE_NUM',
+  name: 'shape_dist_traveled',
+  required: false
+}
+const stopSequenceField = {
+  columnWidth: 6,
+  inputType: 'POSITIVE_INT',
+  name: 'stop_sequence',
+  required: true
+}
+
+describe('editor > util > gtfs >', () => {
+  describe('validate', () => {
+    describe('POSITIVE_INT', () => {
+      it('undefined should be invalid for required field', () => {
+        expect(
+          validate(stopSequenceField, undefined, null, null, defaultTablesData)
+        ).toEqual({
+          field: 'stop_sequence',
+          invalid: true,
+          reason: 'Required field must not be empty'
+        })
+      })
+
+      it('empty string should be invalid for required field', () => {
+        expect(
+          validate(stopSequenceField, '', null, null, defaultTablesData)
+        ).toEqual({
+          field: 'stop_sequence',
+          invalid: true,
+          reason: 'Required field must not be empty'
+        })
+      })
+
+      it('string with alphanumeric characters should be invalid', () => {
+        expect(
+          validate(stopSequenceField, 'abcd123', null, null, defaultTablesData)
+        ).toEqual({
+          field: 'stop_sequence',
+          invalid: true,
+          reason: 'Field must be a valid number'
+        })
+      })
+
+      it('-1 should be invalid', () => {
+        expect(
+          validate(routeSortOrderField, '-1', null, null, defaultTablesData)
+        ).toEqual({
+          field: 'route_sort_order',
+          invalid: true,
+          reason: 'Field must be a positive number'
+        })
+      })
+
+      it('1 should be valid', () => {
+        expect(
+          validate(routeSortOrderField, '1', null, null, defaultTablesData)
+        ).toEqual(false)
+      })
+
+      it('1.5 should be invalid', () => {
+        expect(
+          validate(routeSortOrderField, '1.5', null, null, defaultTablesData)
+        ).toEqual({
+          field: 'route_sort_order',
+          invalid: true,
+          reason: 'Field must be a positive integer'
+        })
+      })
+
+      it('1.0 should be invalid', () => {
+        expect(
+          validate(routeSortOrderField, '1.0', null, null, defaultTablesData)
+        ).toEqual({
+          field: 'route_sort_order',
+          invalid: true,
+          reason: 'Field must be a positive integer'
+        })
+      })
+
+      it('1. should be invalid', () => {
+        expect(
+          validate(routeSortOrderField, '1.', null, null, defaultTablesData)
+        ).toEqual({
+          field: 'route_sort_order',
+          invalid: true,
+          reason: 'Field must be a positive integer'
+        })
+      })
+    })
+
+    describe('POSITIVE_NUM', () => {
+      it('-1 should be invalid', () => {
+        expect(
+          validate(shapedDistTraveledField, '-1', null, null, defaultTablesData)
+        ).toEqual({
+          field: 'shape_dist_traveled',
+          invalid: true,
+          reason: 'Field must be a positive number'
+        })
+      })
+
+      it('1 should be valid', () => {
+        expect(
+          validate(shapedDistTraveledField, '1', null, null, defaultTablesData)
+        ).toEqual(false)
+      })
+
+      it('1.5 should be valid', () => {
+        expect(
+          validate(shapedDistTraveledField, '1.5', null, null, defaultTablesData)
+        ).toEqual(false)
+      })
+    })
+  })
+})

--- a/lib/editor/util/validation.js
+++ b/lib/editor/util/validation.js
@@ -19,6 +19,12 @@ export function doesNotExist (value: any): boolean {
   return value === '' || value === null || typeof value === 'undefined'
 }
 
+/**
+ * Validate if a value is ok.
+ *
+ * Returns false if the value is ok.
+ * Returns an EditorValidationIssue object if the value is not ok.
+ */
 export function validate (
   field: Field,
   value: any,
@@ -246,6 +252,35 @@ export function validate (
     case 'COLOR':
     case 'POSITIVE_INT':
     case 'POSITIVE_NUM':
+      if (isRequiredButEmpty) {
+        return {field: name, invalid: isRequiredButEmpty, reason}
+      }
+      const num = parseFloat(value)
+
+      // make sure value is parseable to a number
+      if (isNaN(num)) {
+        return {field: name, invalid: true, reason: 'Field must be a valid number'}
+      }
+
+      // make sure value is positive
+      if (num < 0) {
+        return {field: name, invalid: true, reason: 'Field must be a positive number'}
+      }
+
+      // check for floating value if input type is POSITIVE_INT
+      if (
+        inputType === 'POSITIVE_INT' &&
+        (
+          num % 1 > 0 ||
+          (
+            value.indexOf &&
+            value.indexOf('.') > -1
+          )
+        )
+      ) {
+        return {field: name, invalid: true, reason: 'Field must be a positive integer'}
+      }
+      return false
     default:
       if (isRequiredButEmpty) {
         return {field: name, invalid: isRequiredButEmpty, reason}

--- a/lib/editor/util/validation.js
+++ b/lib/editor/util/validation.js
@@ -31,11 +31,55 @@ export function validate (
   entities: ?Array<Entity>,
   entity: ?Entity,
   tableData: EditorTables
-): EditorValidationIssue | boolean {
+): EditorValidationIssue | false {
   const {inputType, required, name} = field
-  const isRequiredButEmpty = required && doesNotExist(value)
+  const valueDoesNotExist = doesNotExist(value)
+  const isRequiredButEmpty = required && valueDoesNotExist
+  const isOptionalAndEmpty = !required && valueDoesNotExist
   let reason = 'Required field must not be empty'
   const agencies = getTableById(tableData, 'agency')
+
+  // setting as a variable here because of eslint bug
+  type CheckPositiveOutput = {
+    num?: number,
+    result: false | EditorValidationIssue
+  }
+
+  /**
+   * Checks whether value is a positive number
+   */
+  function checkPositiveNumber (): CheckPositiveOutput {
+    if (isRequiredButEmpty) {
+      return {
+        result: {field: name, invalid: isRequiredButEmpty, reason}
+      }
+    } else if (isOptionalAndEmpty) {
+      return {
+        result: false
+      }
+    }
+    const num = parseFloat(value)
+
+    // make sure value is parseable to a number
+    if (isNaN(num)) {
+      return {
+        result: {field: name, invalid: true, reason: 'Field must be a valid number'}
+      }
+    }
+
+    // make sure value is positive
+    if (num < 0) {
+      return {
+        result: {field: name, invalid: true, reason: 'Field must be a positive number'}
+      }
+    }
+
+    return {
+      num,
+      result: false
+    }
+  }
+
   switch (inputType) {
     case 'GTFS_ID':
       // Indices contains list of all indexes of occurrences of the ID value.
@@ -198,11 +242,12 @@ export function validate (
         name === 'agency_id' &&
         agencies.length > 1
       ) {
-        const missingId = doesNotExist(value)
-        if (missingId) {
-          reason =
-            'Field must be populated for feeds with more than one agency.'
-          return {field: name, invalid: missingId, reason}
+        if (valueDoesNotExist) {
+          return {
+            field: name,
+            invalid: true,
+            reason: 'Field must be populated for feeds with more than one agency.'
+          }
         }
       }
       return false
@@ -247,27 +292,15 @@ export function validate (
       }
       return false
     case 'POSITIVE_INT':
-    case 'POSITIVE_NUM':
-      if (isRequiredButEmpty) {
-        return {field: name, invalid: isRequiredButEmpty, reason}
-      }
-      const num = parseFloat(value)
+      const positiveNumberCheck = checkPositiveNumber()
+      if (positiveNumberCheck.result !== false) return positiveNumberCheck.result
+      if (isOptionalAndEmpty) return false
 
-      // make sure value is parseable to a number
-      if (isNaN(num)) {
-        return {field: name, invalid: true, reason: 'Field must be a valid number'}
-      }
-
-      // make sure value is positive
-      if (num < 0) {
-        return {field: name, invalid: true, reason: 'Field must be a positive number'}
-      }
-
-      // check for floating value if input type is POSITIVE_INT
+      // check for floating value or decimal point
       if (
-        inputType === 'POSITIVE_INT' &&
+        typeof positiveNumberCheck.num === 'number' &&
         (
-          num % 1 > 0 ||
+          positiveNumberCheck.num % 1 > 0 ||
           (
             value.indexOf &&
             value.indexOf('.') > -1
@@ -277,6 +310,8 @@ export function validate (
         return {field: name, invalid: true, reason: 'Field must be a positive integer'}
       }
       return false
+    case 'POSITIVE_NUM':
+      return checkPositiveNumber().result
     case 'GTFS_ROUTE':
     case 'GTFS_STOP':
     case 'DATE':

--- a/lib/editor/util/validation.js
+++ b/lib/editor/util/validation.js
@@ -1,11 +1,13 @@
 // @flow
+
 import clone from 'lodash/cloneDeep'
 import moment from 'moment'
 import validator from 'validator'
 
 import {getTableById} from './gtfs'
 
-import type {EditorTableData, Entity, Field, ScheduleException} from '../../types'
+import type {Entity, Field, ScheduleException} from '../../types'
+import type {EditorTables} from '../../types/reducers'
 
 export type EditorValidationIssue = {
   field: string,
@@ -20,9 +22,9 @@ export function doesNotExist (value: any): boolean {
 export function validate (
   field: Field,
   value: any,
-  entities: Array<Entity>,
-  entity: Entity,
-  tableData: EditorTableData
+  entities: ?Array<Entity>,
+  entity: ?Entity,
+  tableData: EditorTables
 ): EditorValidationIssue | boolean {
   const {inputType, required, name} = field
   const isRequiredButEmpty = required && doesNotExist(value)
@@ -38,10 +40,13 @@ export function validate (
         indices.push(idx)
         idx = idList.indexOf(value, idx + 1)
       }
-      const isNotUnique =
+      const isNotUnique = !!(
+        entities &&
+        entity &&
         value &&
         (indices.length > 1 ||
           (indices.length > 0 && entities[indices[0]].id !== entity.id))
+      )
       if (isRequiredButEmpty || isNotUnique) {
         if (isNotUnique) {
           reason = 'Identifier must be unique'
@@ -51,11 +56,12 @@ export function validate (
         return false
       }
     case 'TEXT':
-      if (name === 'route_short_name' && !value && entity.route_long_name) {
+      if (name === 'route_short_name' && !value && entity && entity.route_long_name) {
         return false
       } else if (
         name === 'route_long_name' &&
         !value &&
+        entity &&
         entity.route_short_name
       ) {
         return false
@@ -161,7 +167,7 @@ export function validate (
         'sunday'
       ]
       for (var i = 0; i < DAYS_OF_WEEK.length; i++) {
-        if (entity[DAYS_OF_WEEK[i]]) {
+        if (entity && entity[DAYS_OF_WEEK[i]]) {
           hasService = true
         }
       }
@@ -199,7 +205,8 @@ export function validate (
       // Clone exceptions to avoid mutating table in store.
       const scheduleExceptions: Array<ScheduleException> = clone(getTableById(tableData, 'scheduleexception'))
       if (entity) {
-        const exceptionIndex = scheduleExceptions.findIndex(se => se.id === entity.id)
+        const entityId = entity.id
+        const exceptionIndex = scheduleExceptions.findIndex(se => se.id === entityId)
         if (exceptionIndex !== -1) {
           scheduleExceptions.splice(exceptionIndex, 1)
         }

--- a/lib/editor/util/validation.js
+++ b/lib/editor/util/validation.js
@@ -246,10 +246,6 @@ export function validate (
         }
       }
       return false
-    case 'GTFS_ROUTE':
-    case 'GTFS_STOP':
-    case 'DATE':
-    case 'COLOR':
     case 'POSITIVE_INT':
     case 'POSITIVE_NUM':
       if (isRequiredButEmpty) {
@@ -281,6 +277,10 @@ export function validate (
         return {field: name, invalid: true, reason: 'Field must be a positive integer'}
       }
       return false
+    case 'GTFS_ROUTE':
+    case 'GTFS_STOP':
+    case 'DATE':
+    case 'COLOR':
     default:
       if (isRequiredButEmpty) {
         return {field: name, invalid: isRequiredButEmpty, reason}

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -303,10 +303,10 @@ export type FeedWithValidation = {
 }
 
 export type Field = {
-  adminOnly: boolean,
+  adminOnly?: boolean,
   columnWidth: number,
-  datatools: boolean,
-  displayName: string,
+  datatools?: boolean,
+  displayName?: string,
   helpContent?: string,
   inputType: string,
   name: string,
@@ -527,13 +527,6 @@ export type ScheduleException = {|
   name: string,
   removed_service: ?Array<string>
 |}
-
-export type EditorTableData = {
-  agency: Array<GtfsAgency>,
-  feedinfo: FeedInfo,
-  route: Array<GtfsRoute>,
-  scheduleexception?: Array<ScheduleException>
-}
 
 export type ServiceCalendar = {|
   description: string,


### PR DESCRIPTION
The field `route_sort_order` was missing from the route table in the gtfs yml spec.  This fixes that.

This depends on https://github.com/conveyal/gtfs-lib/pull/154 being used by datatools-server to fully work.